### PR TITLE
fix: 🐛 fixed text domains

### DIFF
--- a/includes/Admin/Order.php
+++ b/includes/Admin/Order.php
@@ -35,7 +35,7 @@ class Order {
 		$histories = Helper::get_subscriptions_from_order( $order->get_id() ); // HPOS: Safe, uses custom table for subscription relations.
 		if ( count( $histories ) > 0 ) :
 			?>
-			<div class="subscrpt-order-label"><?php echo esc_html_e( 'Subscription order', 'sdevs_subscrpt' ); ?></div>
+			<div class="subscrpt-order-label"><?php echo esc_html_e( 'Subscription order', 'wp_subscription' ); ?></div>
 			<?php
 		endif;
 	}
@@ -53,7 +53,7 @@ class Order {
 			$order = wc_get_order( $order_id ); // HPOS: Safe, uses WooCommerce CRUD.
 			add_meta_box(
 				'subscrpt_order_related',
-				__( 'Related Subscriptions', 'sdevs_subscrpt' ),
+				__( 'Related Subscriptions', 'wp_subscription' ),
 				array( $this, 'subscrpt_order_related' ),
 				$screen,
 				'normal',

--- a/includes/Admin/Product.php
+++ b/includes/Admin/Product.php
@@ -72,7 +72,7 @@ class Product {
 	 */
 	public function register_tab( $tabs ) {
 		$tabs['sdevs_subscription'] = array(
-			'label'    => __( 'Subscription', 'sdevs_subscrpt' ),
+			'label'    => __( 'Subscription', 'wp_subscription' ),
 			'class'    => array( 'show_if_simple', 'show_if_subscription' ),
 			'target'   => 'sdevs_subscription_options',
 			'priority' => 11,
@@ -101,8 +101,8 @@ class Product {
 		$product_type_options['subscrpt_enable'] = array(
 			'id'            => 'subscrpt_enable',
 			'wrapper_class' => $wrapper_class,
-			'label'         => __( 'Subscription', 'sdevs_subscrpt' ),
-			'description'   => __( 'Enable Subscriptions', 'sdevs_subscrpt' ),
+			'label'         => __( 'Subscription', 'wp_subscription' ),
+			'description'   => __( 'Enable Subscriptions', 'wp_subscription' ),
 			'default'       => $value,
 		);
 
@@ -118,10 +118,10 @@ class Product {
 				do_action( 'subscrpt_simple_pro_fields', get_the_ID() );
 			} else {
 				$timing_types          = array(
-					'days'   => __( 'Daily', 'sdevs_subscrpt' ),
-					'weeks'  => __( 'Weekly', 'sdevs_subscrpt' ),
-					'months' => __( 'Monthly', 'sdevs_subscrpt' ),
-					'years'  => __( 'Yearly', 'sdevs_subscrpt' ),
+					'days'   => __( 'Daily', 'wp_subscription' ),
+					'weeks'  => __( 'Weekly', 'wp_subscription' ),
+					'months' => __( 'Monthly', 'wp_subscription' ),
+					'years'  => __( 'Yearly', 'wp_subscription' ),
 				);
 				$trial_timing_types    = get_timing_types();
 				$subscrpt_timing       = null;

--- a/includes/Admin/Required.php
+++ b/includes/Admin/Required.php
@@ -50,10 +50,10 @@ class Required {
     public function install_plugin_notice() {
         if ( $this->plugin_file ) {
             $id    = 'sdevs-activate-plugin';
-            $label = __( 'Activate Woocommerce', 'sdevs_subscrpt' );
+            $label = __( 'Activate Woocommerce', 'wp_subscription' );
         } else {
             $id    = 'sdevs-install-plugin';
-            $label = __( 'Install Woocommerce', 'sdevs_subscrpt' );
+            $label = __( 'Install Woocommerce', 'wp_subscription' );
         }
 
         include 'views/required-notice.php';

--- a/includes/Admin/Subscriptions.php
+++ b/includes/Admin/Subscriptions.php
@@ -108,10 +108,10 @@ class Subscriptions {
 	 * @return array
 	 */
 	public function add_custom_columns( $columns ) {
-		$columns['subscrpt_start_date'] = __( 'Start Date', 'sdevs_subscrpt' );
-		$columns['subscrpt_customer']   = __( 'Customer', 'sdevs_subscrpt' );
-		$columns['subscrpt_next_date']  = __( 'Next Date', 'sdevs_subscrpt' );
-		$columns['subscrpt_status']     = __( 'Status', 'sdevs_subscrpt' );
+		$columns['subscrpt_start_date'] = __( 'Start Date', 'wp_subscription' );
+		$columns['subscrpt_customer']   = __( 'Customer', 'wp_subscription' );
+		$columns['subscrpt_next_date']  = __( 'Next Date', 'wp_subscription' );
+		$columns['subscrpt_status']     = __( 'Status', 'wp_subscription' );
 		unset( $columns['date'] );
 		unset( $columns['cb'] );
 
@@ -156,7 +156,7 @@ class Subscriptions {
 				<?php
 			}
 		} else {
-			esc_html_e( 'Order not found !!', 'sdevs_subscrpt' );
+			esc_html_e( 'Order not found !!', 'wp_subscription' );
 		}
 	}
 
@@ -167,7 +167,7 @@ class Subscriptions {
 		remove_meta_box( 'submitdiv', 'subscrpt_order', 'side' );
 		add_meta_box(
 			'subscrpt_order_save_post',
-			__( 'Subscription Action', 'sdevs_subscrpt' ),
+			__( 'Subscription Action', 'wp_subscription' ),
 			array( $this, 'subscrpt_order_save_post' ),
 			'subscrpt_order',
 			'side',
@@ -176,7 +176,7 @@ class Subscriptions {
 
 		add_meta_box(
 			'subscrpt_customer_info',
-			__( 'Customer Info', 'sdevs_subscrpt' ),
+			__( 'Customer Info', 'wp_subscription' ),
 			array( $this, 'customer_info' ),
 			'subscrpt_order',
 			'side',
@@ -185,7 +185,7 @@ class Subscriptions {
 
 		add_meta_box(
 			'subscrpt_order_info',
-			__( 'Subscription Info', 'sdevs_subscrpt' ),
+			__( 'Subscription Info', 'wp_subscription' ),
 			array( $this, 'subscrpt_order_info' ),
 			'subscrpt_order',
 			'normal',
@@ -194,7 +194,7 @@ class Subscriptions {
 
 		add_meta_box(
 			'subscrpt_order_history',
-			__( 'Subscription History', 'sdevs_subscrpt' ),
+			__( 'Subscription History', 'wp_subscription' ),
 			array( $this, 'order_histories' ),
 			'subscrpt_order',
 			'normal',
@@ -203,7 +203,7 @@ class Subscriptions {
 
 		add_meta_box(
 			'subscrpt_order_activities',
-			__( 'Subscription Activities', 'sdevs_subscrpt' ),
+			__( 'Subscription Activities', 'wp_subscription' ),
 			array( $this, 'order_activities' ),
 			'subscrpt_order',
 			'normal',
@@ -271,23 +271,23 @@ class Subscriptions {
 	public function subscrpt_order_save_post() {
 		$actions_data = array(
 			'active'       => array(
-				'label' => __( 'Activate Subscription', 'sdevs_subscrpt' ),
+				'label' => __( 'Activate Subscription', 'wp_subscription' ),
 				'value' => 'active',
 			),
 			'pending'      => array(
-				'label' => __( 'Pending Subscription', 'sdevs_subscrpt' ),
+				'label' => __( 'Pending Subscription', 'wp_subscription' ),
 				'value' => 'pending',
 			),
 			'expire'       => array(
-				'label' => __( 'Expire Subscription', 'sdevs_subscrpt' ),
+				'label' => __( 'Expire Subscription', 'wp_subscription' ),
 				'value' => 'expired',
 			),
 			'pe_cancelled' => array(
-				'label' => __( 'Pending Cancel Subscription', 'sdevs_subscrpt' ),
+				'label' => __( 'Pending Cancel Subscription', 'wp_subscription' ),
 				'value' => 'pe_cancelled',
 			),
 			'cancelled'    => array(
-				'label' => __( 'Cancel Subscription', 'sdevs_subscrpt' ),
+				'label' => __( 'Cancel Subscription', 'wp_subscription' ),
 				'value' => 'cancelled',
 			),
 		);
@@ -346,51 +346,51 @@ class Subscriptions {
 		$product_link = get_the_permalink( $order_item->get_product_id() );
 		$rows         = array(
 			'product'          => array(
-				'label' => __( 'Product', 'sdevs_subscrpt' ),
+				'label' => __( 'Product', 'wp_subscription' ),
 				'value' => '<a href="' . esc_html( $product_link ) . '" target="_blank">' . esc_html( $product_name ) . '</a>',
 			),
 			'cost'             => array(
-				'label' => __( 'Cost', 'sdevs_subscrpt' ),
+				'label' => __( 'Cost', 'wp_subscription' ),
 				'value' => Helper::format_price_with_order_item( get_post_meta( get_the_ID(), '_subscrpt_price', true ), $order_item->get_id() ),
 			),
 			'quantity'         => array(
-				'label' => __( 'Qty', 'sdevs_subscrpt' ),
+				'label' => __( 'Qty', 'wp_subscription' ),
 				'value' => "x{$order_item->get_quantity()}",
 			),
 			'start_date'       => array(
-				'label' => __( 'Started date', 'sdevs_subscrpt' ),
+				'label' => __( 'Started date', 'wp_subscription' ),
 				'value' => ! empty( $start_date ) ? gmdate( 'F d, Y', $trial && $trial_start_date ? $trial_start_date : $start_date ) : '-',
 			),
 			'next_date'        => array(
-				'label' => __( 'Payment due date', 'sdevs_subscrpt' ),
+				'label' => __( 'Payment due date', 'wp_subscription' ),
 				'value' => ! empty( $next_date ) ? gmdate( 'F d, Y', $trial && $trial_end_date && 'on' === $trial_mode ? $trial_end_date : ( $next_date ?? '-' ) ) : '-',
 			),
 			'status'           => array(
-				'label' => __( 'Status', 'sdevs_subscrpt' ),
+				'label' => __( 'Status', 'wp_subscription' ),
 				'value' => '<span class="subscrpt-' . get_post_status() . '">' . get_post_status_object( get_post_status() )->label . '</span>',
 			),
 			'payment_method'   => array(
-				'label' => __( 'Payment Method', 'sdevs_subscrpt' ),
+				'label' => __( 'Payment Method', 'wp_subscription' ),
 				'value' => empty( $order->get_payment_method_title() ) ? '-' : $order->get_payment_method_title(),
 			),
 			'billing_address'  => array(
-				'label' => __( 'Billing', 'sdevs_subscrpt' ),
-				'value' => $order->get_formatted_billing_address() ? $order->get_formatted_billing_address() : __( 'No billing address set.', 'sdevs_subscrpt' ),
+				'label' => __( 'Billing', 'wp_subscription' ),
+				'value' => $order->get_formatted_billing_address() ? $order->get_formatted_billing_address() : __( 'No billing address set.', 'wp_subscription' ),
 			),
 			'shipping_address' => array(
-				'label' => __( 'Shipping', 'sdevs_subscrpt' ),
-				'value' => $order->get_formatted_shipping_address() ? $order->get_formatted_shipping_address() : __( 'No shipping address set.', 'sdevs_subscrpt' ),
+				'label' => __( 'Shipping', 'wp_subscription' ),
+				'value' => $order->get_formatted_shipping_address() ? $order->get_formatted_shipping_address() : __( 'No shipping address set.', 'wp_subscription' ),
 			),
 		);
 		if ( $trial ) {
 			$rows = array_slice( $rows, 0, 3, true ) + array(
 				'trial'        => array(
-					'label' => __( 'Trial', 'sdevs_subscrpt' ),
+					'label' => __( 'Trial', 'wp_subscription' ),
 					'value' => $trial,
 				),
 				'trial_period' => array(
-					'label' => __( 'Trial Period', 'sdevs_subscrpt' ),
-					'value' => ( $trial_start_date && $trial_end_date ? ' [ ' . gmdate( 'F d, Y', $trial_start_date ) . ' - ' . gmdate( 'F d, Y', $trial_end_date ) . ' ] ' : __( 'Trial isn\'t activated yet! ', 'sdevs_subscrpt' ) ),
+					'label' => __( 'Trial Period', 'wp_subscription' ),
+					'value' => ( $trial_start_date && $trial_end_date ? ' [ ' . gmdate( 'F d, Y', $trial_start_date ) . ' - ' . gmdate( 'F d, Y', $trial_end_date ) . ' ] ' : __( 'Trial isn\'t activated yet! ', 'wp_subscription' ) ),
 				),
 			) + array_slice( $rows, 3, count( $rows ) - 1, true );
 		}
@@ -402,7 +402,7 @@ class Subscriptions {
 				$new_rows[ $key ] = $value;
 				if ( 'payment_method' === $key ) {
 					$new_rows['stripe_auto_renewal'] = array(
-						'label' => __( 'Stripe Auto Renewal', 'sdevs_subscrpt' ),
+						'label' => __( 'Stripe Auto Renewal', 'wp_subscription' ),
 						'value' => '0' !== $is_auto_renew ? 'On' : 'Off',
 					);
 				}

--- a/includes/Admin/views/product-form.php
+++ b/includes/Admin/views/product-form.php
@@ -3,22 +3,22 @@
     <div class="show_if_subscription">
         <input name="_subscript_nonce" type="hidden"
                value="<?php echo esc_attr( wp_create_nonce( '_subscript_edit_product_nonce' ) ); ?>"/>
-        <strong style="margin: 10px;"><?php esc_html_e( 'Subscription Settings', 'sdevs_subscrpt' ); ?></strong>
+        <strong style="margin: 10px;"><?php esc_html_e( 'Subscription Settings', 'wp_subscription' ); ?></strong>
         <?php
 
         woocommerce_wp_select(
             array(
                 'id'          => 'subscrpt_timing',
-                'label'       => __( 'Users will pay', 'sdevs_subscrpt' ),
+                'label'       => __( 'Users will pay', 'wp_subscription' ),
                 'value'       => $subscrpt_timing,
                 'options'     => $timing_types,
-                'description' => __( 'Set the length of each recurring subscription period to daily, weekly, monthly or annually.', 'sdevs_subscrpt' ),
+                'description' => __( 'Set the length of each recurring subscription period to daily, weekly, monthly or annually.', 'wp_subscription' ),
                 'desc_tip'    => true,
             )
         );
         ?>
         <p class="form-field subscrpt_field">
-            <label for="subscrpt_trial_time"><?php esc_html_e( 'Offer a free trial of', 'sdevs_subscrpt' ); ?></label>
+            <label for="subscrpt_trial_time"><?php esc_html_e( 'Offer a free trial of', 'wp_subscription' ); ?></label>
             <input type="number" class="short" name="subscrpt_trial_time" id="subscrpt_trial_time"
                    value="<?php echo esc_attr( $subscrpt_trial_time ); ?>"/>
             <select name="subscrpt_trial_timing" id="subscrpt_trial_timing">
@@ -33,7 +33,7 @@
                 <?php endforeach; ?>
             </select>
             <small
-                class="description"><?php esc_html_e( 'You can offer a free trial of this subscription. In this way the user can purchase the subscription and will pay when the trial period expires.', 'sdevs_subscrpt' ); ?></small>
+                class="description"><?php esc_html_e( 'You can offer a free trial of this subscription. In this way the user can purchase the subscription and will pay when the trial period expires.', 'wp_subscription' ); ?></small>
         </p>
 
         <?php
@@ -41,10 +41,10 @@
         woocommerce_wp_text_input(
             array(
                 'id'          => 'subscrpt_cart_txt',
-                'label'       => __( 'Add to Cart Text', 'sdevs_subscrpt' ),
+                'label'       => __( 'Add to Cart Text', 'wp_subscription' ),
                 'type'        => 'text',
                 'value'       => $subscrpt_cart_txt,
-                'description' => __( 'change Add to Cart Text default is "subscribe"', 'sdevs_subscrpt' ),
+                'description' => __( 'change Add to Cart Text default is "subscribe"', 'wp_subscription' ),
                 'desc_tip'    => true,
             )
         );
@@ -52,13 +52,13 @@
         woocommerce_wp_select(
             array(
                 'id'          => 'subscrpt_user_cancel',
-                'label'       => __( 'Can User Cancel', 'sdevs_subscrpt' ),
+                'label'       => __( 'Can User Cancel', 'wp_subscription' ),
                 'value'       => $subscrpt_user_cancell,
                 'options'     => array(
-                    'yes' => __( 'Yes', 'sdevs_subscrpt' ),
-                    'no'  => __( 'No', 'sdevs_subscrpt' ),
+                    'yes' => __( 'Yes', 'wp_subscription' ),
+                    'no'  => __( 'No', 'wp_subscription' ),
                 ),
-                'description' => __( 'if "Yes",then user can be cancelled."No" means cannot do this !!', 'sdevs_subscrpt' ),
+                'description' => __( 'if "Yes",then user can be cancelled."No" means cannot do this !!', 'wp_subscription' ),
                 'desc_tip'    => true,
             )
         );
@@ -66,14 +66,14 @@
         woocommerce_wp_select(
             array(
                 'id'          => 'subscrpt_limit',
-                'label'       => __( 'Limit subscription', 'sdevs_subscrpt' ),
+                'label'       => __( 'Limit subscription', 'wp_subscription' ),
                 'options'     => array(
-                    'unlimited' => __( 'Do not limit', 'sdevs_subscrpt' ),
-                    'one'       => __( 'allow only one active subscription', 'sdevs_subscrpt' ),
-                    'only_one'  => __( 'allow only one subscription of any status', 'sdevs_subscrpt' ),
+                    'unlimited' => __( 'Do not limit', 'wp_subscription' ),
+                    'one'       => __( 'allow only one active subscription', 'wp_subscription' ),
+                    'only_one'  => __( 'allow only one subscription of any status', 'wp_subscription' ),
                 ),
                 'value'       => $subscrpt_limit,
-                'description' => __( 'Set optional limits for this product subscription.', 'sdevs_subscrpt' ),
+                'description' => __( 'Set optional limits for this product subscription.', 'wp_subscription' ),
                 'desc_tip'    => true,
             )
         );

--- a/includes/Admin/views/related-subscriptions.php
+++ b/includes/Admin/views/related-subscriptions.php
@@ -6,10 +6,10 @@
 
 			use SpringDevs\Subscription\Illuminate\Helper;
 
-			esc_html_e( 'Started on', 'sdevs_subscrpt' ); ?></th>
-			<th><?php esc_html_e( 'Recurring', 'sdevs_subscrpt' ); ?></th>
-			<th><?php esc_html_e( 'Expiry date', 'sdevs_subscrpt' ); ?></th>
-			<th><?php esc_html_e( 'Status', 'sdevs_subscrpt' ); ?></th>
+			esc_html_e( 'Started on', 'wp_subscription' ); ?></th>
+			<th><?php esc_html_e( 'Recurring', 'wp_subscription' ); ?></th>
+			<th><?php esc_html_e( 'Expiry date', 'wp_subscription' ); ?></th>
+			<th><?php esc_html_e( 'Status', 'wp_subscription' ); ?></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -28,7 +28,7 @@
 						<a href="<?php echo esc_html( get_edit_post_link( $history->subscription_id ) ); ?>" target="_blank">#<?php echo esc_html( $history->subscription_id ); ?> - <?php echo esc_html( $order_item->get_name() ); ?></a>
 					</td>
 					<td>
-						<?php echo null == $trial ? ( ! empty( $start_date ) ? esc_html( gmdate( 'F d, Y', $start_date ) ) : '-' ) : '+' . esc_html( $trial ) . ' ' . __( 'free trial', 'sdevs_subscrpt' ); ?>
+						<?php echo null == $trial ? ( ! empty( $start_date ) ? esc_html( gmdate( 'F d, Y', $start_date ) ) : '-' ) : '+' . esc_html( $trial ) . ' ' . __( 'free trial', 'wp_subscription' ); ?>
 					</td>
 					<td><?php echo wp_kses_post( Helper::format_price_with_order_item( $price, $order_item->get_id() ) ); ?></td>
 					<td><?php echo esc_html( ! empty( $start_date ) && ! empty( $next_date ) ? ( $trial == null ? gmdate( 'F d, Y', $next_date ) : gmdate( 'F d, Y', $start_date ) ) : '-' ); ?></td>

--- a/includes/Admin/views/required-notice.php
+++ b/includes/Admin/views/required-notice.php
@@ -13,7 +13,7 @@ STYLE GUIDE FOR WP SUBSCRIPTION ADMIN PAGES:
 		<img src="<?php echo WP_SUBSCRIPTION_ASSETS . '/images/logo.png'; ?>" alt="woocommerce-logo" />
 	</div>
 	<div class="sdevs-notice-content">
-		<h2><?php _e( 'Thanks for using Subscription for WooCommerce', 'sdevs_subscrpt' ); ?></h2>
+		<h2><?php _e( 'Thanks for using Subscription for WooCommerce', 'wp_subscription' ); ?></h2>
 		<p>You must have <a href="https://wordpress.org/plugins/woocommerce/" target="_blank">Woocommerce </a> installed and activated on this website in order to use this plugin.</p>
 	</div>
 	<div class="sdevs-install-notice-button">

--- a/includes/Admin/views/subscription-save-meta.php
+++ b/includes/Admin/views/subscription-save-meta.php
@@ -7,7 +7,7 @@
 ?>
 <p class="subscrpt_sub_box">
     <select id="subscrpt_order_type" name="subscrpt_order_action">
-        <option value="" disabled selected><?php esc_html_e( 'Choose Action', 'sdevs_subscrpt' ); ?></option>
+        <option value="" disabled selected><?php esc_html_e( 'Choose Action', 'wp_subscription' ); ?></option>
         <?php foreach ( $actions as $action_slug ) : ?>
             <?php
                 $action = $actions_data[$action_slug];

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -59,7 +59,7 @@ class Ajax {
 			wp_die( $api );
 		}
 
-		$title = sprintf( __( 'Installing Plugin: %s', 'sdevs_subscrpt' ), $api->name . ' ' . $api->version );
+		$title = sprintf( __( 'Installing Plugin: %s', 'wp_subscription' ), $api->name . ' ' . $api->version );
 		$nonce = 'install-plugin_' . $plugin;
 		$url   = 'update.php?action=install-plugin&plugin=' . urlencode( $plugin );
 

--- a/includes/Frontend/ActionController.php
+++ b/includes/Frontend/ActionController.php
@@ -31,7 +31,7 @@ class ActionController {
 		$action      = sanitize_text_field( wp_unslash( $_GET['action'] ) );
 		$wpnonce     = sanitize_text_field( wp_unslash( $_GET['wpnonce'] ) );
 		if ( ! wp_verify_nonce( $wpnonce, 'subscrpt_nonce' ) ) {
-			wp_die( esc_html( __( 'Sorry !! You cannot permit to access.', 'sdevs_subscrpt' ) ) );
+			wp_die( esc_html( __( 'Sorry !! You cannot permit to access.', 'wp_subscription' ) ) );
 		}
 		if ( 'renew' === $action && ! subscrpt_is_auto_renew_enabled() ) {
 			$this->manual_renew_product( $subscrpt_id );

--- a/includes/Frontend/Cart.php
+++ b/includes/Frontend/Cart.php
@@ -49,14 +49,14 @@ class Cart {
 		foreach ( $cart_items as $key => $cart_item ) {
 			if ( isset( $cart_item['subscription'] ) ) {
 				if ( $enabled ) {
-					$error_notice = __( 'Currently You have an another Subscriptional product on cart !!', 'sdevs_subscrpt' );
+					$error_notice = __( 'Currently You have an another Subscriptional product on cart !!', 'wp_subscription' );
 				} else {
-					$error_notice = __( 'Currently You have Subscriptional product in a cart !!', 'sdevs_subscrpt' );
+					$error_notice = __( 'Currently You have Subscriptional product in a cart !!', 'wp_subscription' );
 				}
 				$failed = true;
 			} elseif ( $enabled ) {
 				$failed       = true;
-				$error_notice = __( 'Your cart isn\'t empty !!', 'sdevs_subscrpt' );
+				$error_notice = __( 'Your cart isn\'t empty !!', 'wp_subscription' );
 			}
 		}
 
@@ -119,7 +119,7 @@ class Cart {
 		if ( isset( $cart_item['subscription'] ) ) {
 			if ( $cart_item['subscription']['trial'] ) {
 				$cart_item_data[] = array(
-					'key'    => __( 'Free Trial', 'sdevs_subscrpt' ),
+					'key'    => __( 'Free Trial', 'wp_subscription' ),
 					'value'  => $cart_item['subscription']['trial'],
 					'hidden' => true,
 					'__experimental_woocommerce_blocks_hidden' => false,
@@ -153,17 +153,17 @@ class Cart {
 					if ( $product->is_type( 'simple' ) ) {
 						if ( Helper::get_typos( 1, $product->get_meta( '_subscrpt_timing_option' ) ) !== $value['subscription']['type'] || $product->get_trial() !== $value['subscription']['trial'] ) {
 							// remove the item.
-							wc_add_notice( __( 'An item which is no longer available was removed from your cart.', 'sdevs_subscrpt' ), 'error' );
+							wc_add_notice( __( 'An item which is no longer available was removed from your cart.', 'wp_subscription' ), 'error' );
 							WC()->cart->remove_cart_item( $key );
 						}
 					} else {
 						// remove the item.
-						wc_add_notice( __( 'An item which is no longer available was removed from your cart.', 'sdevs_subscrpt' ), 'error' );
+						wc_add_notice( __( 'An item which is no longer available was removed from your cart.', 'wp_subscription' ), 'error' );
 						WC()->cart->remove_cart_item( $key );
 					}
 				} elseif ( $product->get_meta( '_subscrpt_enabled' ) ) {
 					// remove the item.
-					wc_add_notice( __( 'An item which is no longer available was removed from your cart.', 'sdevs_subscrpt' ), 'error' );
+					wc_add_notice( __( 'An item which is no longer available was removed from your cart.', 'wp_subscription' ), 'error' );
 					WC()->cart->remove_cart_item( $key );
 				}
 			}
@@ -204,32 +204,32 @@ class Cart {
 	public function extend_cart_schema() {
 		return array(
 			'recurring_totals' => array(
-				'description'      => __( 'List of recurring totals in cart.', 'sdevs_subscrpt' ),
+				'description'      => __( 'List of recurring totals in cart.', 'wp_subscription' ),
 				'type'             => 'array',
 				'readonly'         => true,
 				'recurring_totals' => array(
 					'price'           => array(
-						'description' => __( 'price of the subscription.', 'sdevs_subscrpt' ),
+						'description' => __( 'price of the subscription.', 'wp_subscription' ),
 						'type'        => array( 'string' ),
 						'readonly'    => true,
 					),
 					'time'            => array(
-						'description' => __( 'time of the subscription.', 'sdevs_subscrpt' ),
+						'description' => __( 'time of the subscription.', 'wp_subscription' ),
 						'type'        => array( 'number' ),
 						'readonly'    => true,
 					),
 					'type'            => array(
-						'description' => __( 'type of the subscription.', 'sdevs_subscrpt' ),
+						'description' => __( 'type of the subscription.', 'wp_subscription' ),
 						'type'        => array( 'string' ),
 						'readonly'    => true,
 					),
 					'description'     => array(
-						'description' => __( 'price of the subscription description.', 'sdevs_subscrpt' ),
+						'description' => __( 'price of the subscription description.', 'wp_subscription' ),
 						'type'        => array( 'string' ),
 						'readonly'    => true,
 					),
 					'can_user_cancel' => array(
-						'description' => __( 'Can User Cancel?', 'sdevs_subscrpt' ),
+						'description' => __( 'Can User Cancel?', 'wp_subscription' ),
 						'type'        => array( 'string' ),
 						'readonly'    => true,
 					),
@@ -282,27 +282,27 @@ class Cart {
 	public function extend_cart_item_schema() {
 		return array(
 			'time'       => array(
-				'description' => __( 'time of the subscription type.', 'sdevs_subscrpt' ),
+				'description' => __( 'time of the subscription type.', 'wp_subscription' ),
 				'type'        => array( 'number', 'null' ),
 				'readonly'    => true,
 			),
 			'type'       => array(
-				'description' => __( 'the subscription type.', 'sdevs_subscrpt' ),
+				'description' => __( 'the subscription type.', 'wp_subscription' ),
 				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
 			'trial'      => array(
-				'description' => __( 'the subscription trial.', 'sdevs_subscrpt' ),
+				'description' => __( 'the subscription trial.', 'wp_subscription' ),
 				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
 			'signup_fee' => array(
-				'description' => __( 'Signup Fee amount.', 'sdevs_subscrpt' ),
+				'description' => __( 'Signup Fee amount.', 'wp_subscription' ),
 				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
 			'cost'       => array(
-				'description' => __( 'Recurring amount.', 'sdevs_subscrpt' ),
+				'description' => __( 'Recurring amount.', 'wp_subscription' ),
 				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
@@ -413,16 +413,16 @@ class Cart {
 		}
 		?>
 		<tr class="recurring-total">
-			<th><?php esc_html_e( 'Recurring totals', 'sdevs_subscrpt' ); ?></th>
-			<td data-title="<?php esc_attr_e( 'Recurring totals', 'sdevs_subscrpt' ); ?>">
+			<th><?php esc_html_e( 'Recurring totals', 'wp_subscription' ); ?></th>
+			<td data-title="<?php esc_attr_e( 'Recurring totals', 'wp_subscription' ); ?>">
 				<?php foreach ( $recurrs as $recurr ) : ?>
 					<p>
 						<span><?php echo wp_kses_post( $recurr['price_html'] ); ?></span><br />
-						<small><?php esc_html_e( ( $recurr['trial_status'] ? 'First billing on' : 'Next billing on' ), 'sdevs_subscrpt' ); ?>
+						<small><?php esc_html_e( ( $recurr['trial_status'] ? 'First billing on' : 'Next billing on' ), 'wp_subscription' ); ?>
 							: <?php echo esc_html( $recurr['trial_status'] ? $recurr['start_date'] : $recurr['next_date'] ); ?></small>
 						<?php if ( 'yes' === $recurr['can_user_cancel'] ) : ?>
 							<br>
-							<small><?php esc_html_e( 'You can cancel subscription at any time!', 'sdevs_subscrpt' ); ?></small>
+							<small><?php esc_html_e( 'You can cancel subscription at any time!', 'wp_subscription' ); ?></small>
 						<?php endif; ?>
 					</p>
 				<?php endforeach; ?>

--- a/includes/Frontend/MyAccount.php
+++ b/includes/Frontend/MyAccount.php
@@ -68,25 +68,25 @@ class MyAccount {
 			if ( in_array( $status, array( 'pending', 'active', 'on_hold' ), true ) && 'yes' === $user_cancel ) {
 				$action_buttons['cancel'] = array(
 					'url'   => subscrpt_get_action_url( 'cancelled', $subscrpt_nonce, $id ),
-					'label' => __( 'Cancel', 'sdevs_subscrpt' ),
+					'label' => __( 'Cancel', 'wp_subscription' ),
 					'class' => 'cancel',
 				);
 			} elseif ( trim( $status ) === trim( 'pe_cancelled' ) ) {
 				$action_buttons['reactive'] = array(
 					'url'   => subscrpt_get_action_url( 'reactive', $subscrpt_nonce, $id ),
-					'label' => __( 'Reactive', 'sdevs_subscrpt' ),
+					'label' => __( 'Reactive', 'wp_subscription' ),
 				);
 			} elseif ( 'expired' === $status && 'pending' !== $order->get_status() ) {
 				$action_buttons['renew'] = array(
 					'url'   => subscrpt_get_action_url( 'renew', $subscrpt_nonce, $id ),
-					'label' => __( 'Renew', 'sdevs_subscrpt' ),
+					'label' => __( 'Renew', 'wp_subscription' ),
 				);
 			}
 
 			if ( 'pending' === $order->get_status() ) {
 				$action_buttons['pay_now'] = array(
 					'url'   => $order->get_checkout_payment_url(),
-					'label' => __( 'Pay now', 'sdevs_subscrpt' ),
+					'label' => __( 'Pay now', 'wp_subscription' ),
 				);
 			}
 		}
@@ -102,12 +102,12 @@ class MyAccount {
 			if ( '0' === $is_auto_renew ) {
 				$action_buttons['auto-renew-on'] = array(
 					'url'   => subscrpt_get_action_url( 'renew-on', $subscrpt_nonce, $id ),
-					'label' => __( 'Turn on Auto Renewal', 'sdevs_subscrpt' ),
+					'label' => __( 'Turn on Auto Renewal', 'wp_subscription' ),
 				);
 			} else {
 				$action_buttons['auto-renew-off'] = array(
 					'url'   => subscrpt_get_action_url( 'renew-off', $subscrpt_nonce, $id ),
-					'label' => __( 'Turn off Auto Renewal', 'sdevs_subscrpt' ),
+					'label' => __( 'Turn off Auto Renewal', 'wp_subscription' ),
 				);
 			}
 		}
@@ -152,7 +152,7 @@ class MyAccount {
 	 */
 	public function change_single_title( string $title ): string {
 		/* translators: %s: Subscription ID */
-		return sprintf( __( 'Subscription #%s', 'sdevs_subscrpt' ), get_query_var( 'view-subscription' ) );
+		return sprintf( __( 'Subscription #%s', 'wp_subscription' ), get_query_var( 'view-subscription' ) );
 	}
 
 	/**
@@ -166,7 +166,7 @@ class MyAccount {
 		global $wp_query;
 		$is_endpoint = isset( $wp_query->query_vars['subscriptions'] );
 		if ( $is_endpoint && ! is_admin() && is_account_page() ) {
-			$title = __( 'My Subscriptions', 'sdevs_subscrpt' );
+			$title = __( 'My Subscriptions', 'wp_subscription' );
 		}
 		return $title;
 	}
@@ -180,7 +180,7 @@ class MyAccount {
 	public function custom_my_account_menu_items( array $items ): array {
 		$logout = $items['customer-logout'];
 		unset( $items['customer-logout'] );
-		$items['subscriptions']   = __( 'Subscriptions', 'sdevs_subscrpt' );
+		$items['subscriptions']   = __( 'Subscriptions', 'wp_subscription' );
 		$items['customer-logout'] = $logout;
 		return $items;
 	}

--- a/includes/Frontend/Order.php
+++ b/includes/Frontend/Order.php
@@ -27,7 +27,7 @@ class Order {
 
 		if ( is_array( $histories ) && count( $histories ) > 0 ) :
 			?>
-			<h2 class="woocommerce-order-details__title"><?php esc_html_e( 'Related Subscriptions', 'sdevs_subscrpt' ); ?></h2>
+			<h2 class="woocommerce-order-details__title"><?php esc_html_e( 'Related Subscriptions', 'wp_subscription' ); ?></h2>
 			<?php if ( ! $order->has_status( 'completed' ) ) : ?> 
 				<p><small>Your subscription will be activated when order status is completed.</small></p>
 			<?php endif; ?>
@@ -64,11 +64,11 @@ class Order {
 						</tbody>
 						<tfoot>
 						<tr>
-							<th scope="row"><?php esc_html_e( 'Status', 'sdevs_subscrpt' ); ?>:</th>
+							<th scope="row"><?php esc_html_e( 'Status', 'wp_subscription' ); ?>:</th>
 							<td><?php echo esc_html( get_post_status_object( get_post_status( $post ) )->label ); ?></td>
 						</tr>
 						<tr>
-							<th scope="row"><?php esc_html_e( 'Recurring amount', 'sdevs_subscrpt' ); ?>:</th>
+							<th scope="row"><?php esc_html_e( 'Recurring amount', 'wp_subscription' ); ?>:</th>
 							<td class="woocommerce-table__product-total product-total">
 								<?php echo wp_kses_post( Helper::format_price_with_order_item( $cost, $history->order_item_id ) ); ?>
 							</td>
@@ -77,16 +77,16 @@ class Order {
 						if ( null == $trial_status ) {
 							?>
 							<tr>
-								<th scope="row"><?php esc_html_e( 'Next billing on', 'sdevs_subscrpt' ); ?>:</th>
+								<th scope="row"><?php esc_html_e( 'Next billing on', 'wp_subscription' ); ?>:</th>
 								<td><?php echo $order->has_status( 'completed' ) ? esc_html( gmdate( 'F d, Y', get_post_meta( $history->subscription_id, '_subscrpt_next_date', true ) ) ) : '-'; ?></td>
 							</tr>
 						<?php } else { ?>
 							<tr>
-								<th scope="row"><?php esc_html_e( 'Trial', 'sdevs_subscrpt' ); ?>:</th>
+								<th scope="row"><?php esc_html_e( 'Trial', 'wp_subscription' ); ?>:</th>
 								<td><?php echo esc_html( get_post_meta( $history->subscription_id, '_subscrpt_trial', true ) ); ?></td>
 							</tr>
 							<tr>
-								<th scope="row"><?php esc_html_e( 'First billing on', 'sdevs_subscrpt' ); ?>:</th>
+								<th scope="row"><?php esc_html_e( 'First billing on', 'wp_subscription' ); ?>:</th>
 								<td><?php echo ! empty( $start_date ) ? esc_html( gmdate( 'F d, Y', $start_date ) ) : '-'; ?></td>
 							</tr>
 						<?php } ?>

--- a/includes/Frontend/Product.php
+++ b/includes/Frontend/Product.php
@@ -113,12 +113,12 @@ class Product {
 				if ( ! $unexpired ) {
 					return false;
 				} else {
-					echo '<strong>' . esc_html_e( 'You Already Subscribed These Product!', 'sdevs_subscrpt' ) . '</strong>';
+					echo '<strong>' . esc_html_e( 'You Already Subscribed These Product!', 'wp_subscription' ) . '</strong>';
 				}
 			}
 			if ( 'only_one' === $limit ) {
 				if ( ! Helper::check_trial( $product->get_id() ) ) {
-					echo '<strong>' . esc_html_e( 'You Already Subscribed These Product!', 'sdevs_subscrpt' ) . '</strong>';
+					echo '<strong>' . esc_html_e( 'You Already Subscribed These Product!', 'wp_subscription' ) . '</strong>';
 				}
 			}
 		}
@@ -246,7 +246,7 @@ class Product {
 		$cart_btn_label = $product->get_button_label();
 		$expired        = Helper::subscription_exists( $product->get_id(), 'expired' );
 		if ( $expired ) {
-			$text = __( 'Renew', 'sdevs_subscrpt' );
+			$text = __( 'Renew', 'wp_subscription' );
 		} elseif ( $product->is_enabled() && $cart_btn_label ) {
 			$text = $cart_btn_label;
 		}

--- a/includes/Illuminate/AutoRenewal.php
+++ b/includes/Illuminate/AutoRenewal.php
@@ -34,7 +34,7 @@ class AutoRenewal {
 
 		if ( ! $product ) {
 			if ( ! is_admin() ) {
-				wc_add_notice( __( 'Subscription early renewal order creation failed due to product deletion !', 'sdevs_subscrpt' ), 'error' );
+				wc_add_notice( __( 'Subscription early renewal order creation failed due to product deletion !', 'wp_subscription' ), 'error' );
 			}
 			return false;
 		}
@@ -43,7 +43,7 @@ class AutoRenewal {
 			$product = wc_get_product( $product->get_meta( '_subscrpt_convertation_default_variation_for_renewal', true ) );
 			if ( ! $product ) {
 				if ( ! is_admin() ) {
-					wc_add_notice( __( 'Subscription early renewal order creation failed due to product deletion !', 'sdevs_subscrpt' ), 'error' );
+					wc_add_notice( __( 'Subscription early renewal order creation failed due to product deletion !', 'wp_subscription' ), 'error' );
 				}
 				return false;
 			}

--- a/includes/Illuminate/Emails/RenewReminder.php
+++ b/includes/Illuminate/Emails/RenewReminder.php
@@ -20,8 +20,8 @@ class RenewReminder extends WC_Email {
         $this->customer_email = true;
 
         $this->id          = 'subscrpt_renew_reminder';
-        $this->title       = __( 'Subscription Renewal Reminder', 'sdevs_subscrpt' );
-        $this->description = __( 'This email is sent to customer for renewing subscription before expire.', 'sdevs_subscrpt' );
+        $this->title       = __( 'Subscription Renewal Reminder', 'wp_subscription' );
+        $this->description = __( 'This email is sent to customer for renewing subscription before expire.', 'wp_subscription' );
 
         // email template path.
         $this->set_template( $this->id );
@@ -39,7 +39,7 @@ class RenewReminder extends WC_Email {
      * @return string
      */
     public function get_default_subject(): string {
-        return __( 'Reminder for the Subscription renewal #{subscription_id}', 'sdevs_subscrpt' );
+        return __( 'Reminder for the Subscription renewal #{subscription_id}', 'wp_subscription' );
     }
 
     /**
@@ -90,7 +90,7 @@ class RenewReminder extends WC_Email {
                 'num_of_days_before' => array(
                     'title'   => __(
                         'Number of days before the next subscription payment.',
-                        'sdevs_subscrpt'
+                        'wp_subscription'
                     ),
                     'type'    => 'number',
                     'default' => 7,

--- a/includes/Illuminate/Emails/StatusChangedAdmin.php
+++ b/includes/Illuminate/Emails/StatusChangedAdmin.php
@@ -19,8 +19,8 @@ class StatusChangedAdmin extends WC_Email {
 	 */
 	public function __construct() {
 		$this->id          = 'subscrpt_status_changed_admin_email';
-		$this->title       = __( 'Subscription status changed ( Admin )', 'sdevs_subscrpt' );
-		$this->description = __( 'This email is received when a subscription status changed.', 'sdevs_subscrpt' );
+		$this->title       = __( 'Subscription status changed ( Admin )', 'wp_subscription' );
+		$this->description = __( 'This email is received when a subscription status changed.', 'wp_subscription' );
 
 		// email template path.
 		$this->set_template( $this->id );
@@ -41,7 +41,7 @@ class StatusChangedAdmin extends WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject(): string {
-		return __( '#{subscription_id} subscription status changed', 'sdevs_subscrpt' );
+		return __( '#{subscription_id} subscription status changed', 'wp_subscription' );
 	}
 
 	/**

--- a/includes/Illuminate/Emails/SubscriptionCancelled.php
+++ b/includes/Illuminate/Emails/SubscriptionCancelled.php
@@ -19,8 +19,8 @@ class SubscriptionCancelled extends WC_Email {
 		$this->customer_email = true;
 
 		$this->id          = 'subscrpt_subscription_cancelled_email';
-		$this->title       = __( 'Subscription cancelled', 'sdevs_subscrpt' );
-		$this->description = __( 'This email is sent to customer when a subscription canceled.', 'sdevs_subscrpt' );
+		$this->title       = __( 'Subscription cancelled', 'wp_subscription' );
+		$this->description = __( 'This email is sent to customer when a subscription canceled.', 'wp_subscription' );
 
 		// email template path.
 		$this->set_template( $this->id );
@@ -38,7 +38,7 @@ class SubscriptionCancelled extends WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject(): string {
-		return __( '#{subscription_id} subscription cancelled!', 'sdevs_subscrpt' );
+		return __( '#{subscription_id} subscription cancelled!', 'wp_subscription' );
 	}
 
 	/**

--- a/includes/Illuminate/Emails/SubscriptionExpired.php
+++ b/includes/Illuminate/Emails/SubscriptionExpired.php
@@ -20,8 +20,8 @@ class SubscriptionExpired extends WC_Email {
 		$this->customer_email = true;
 
 		$this->id          = 'subscrpt_subscription_expired_email';
-		$this->title       = __( 'Subscription expired', 'sdevs_subscrpt' );
-		$this->description = __( 'This email is sent to customer when a subscription expired.', 'sdevs_subscrpt' );
+		$this->title       = __( 'Subscription expired', 'wp_subscription' );
+		$this->description = __( 'This email is sent to customer when a subscription expired.', 'wp_subscription' );
 
 		// email template path.
 		$this->set_template( $this->id );
@@ -39,7 +39,7 @@ class SubscriptionExpired extends WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject(): string {
-		return __( '#{subscription_id} subscription expired!', 'sdevs_subscrpt' );
+		return __( '#{subscription_id} subscription expired!', 'wp_subscription' );
 	}
 
 	/**

--- a/includes/Illuminate/Helper.php
+++ b/includes/Illuminate/Helper.php
@@ -24,13 +24,13 @@ class Helper {
 	 */
 	public static function get_typos( $number, $typo ) {
 		if ( 1 === (int) $number && 'days' === $typo ) {
-			return __( 'day', 'sdevs_subscrpt' );
+			return __( 'day', 'wp_subscription' );
 		} elseif ( 1 === (int) $number && 'weeks' === $typo ) {
-			return __( 'week', 'sdevs_subscrpt' );
+			return __( 'week', 'wp_subscription' );
 		} elseif ( 1 === (int) $number && 'months' === $typo ) {
-			return __( 'month', 'sdevs_subscrpt' );
+			return __( 'month', 'wp_subscription' );
 		} elseif ( 1 === (int) $number && 'years' === $typo ) {
-			return __( 'year', 'sdevs_subscrpt' );
+			return __( 'year', 'wp_subscription' );
 		} else {
 			return $typo;
 		}
@@ -284,14 +284,14 @@ class Helper {
 				'comment_author'  => 'Subscription for WooCommerce',
 				'comment_content' => sprintf(
 					// translators: order id.
-					__( 'The order %s has been created for the subscription', 'sdevs_subscrpt' ),
+					__( 'The order %s has been created for the subscription', 'wp_subscription' ),
 					$order_id
 				),
 				'comment_post_ID' => $subscription_id,
 				'comment_type'    => 'order_note',
 			)
 		);
-		update_comment_meta( $comment_id, '_subscrpt_activity', __( 'Renewal Order', 'sdevs_subscrpt' ) );
+		update_comment_meta( $comment_id, '_subscrpt_activity', __( 'Renewal Order', 'wp_subscription' ) );
 
 		$wpdb->insert(
 			$history_table,
@@ -334,14 +334,14 @@ class Helper {
 				'comment_author'  => 'Subscription for WooCommerce',
 				'comment_content' => sprintf(
 					// translators: Order Id.
-					__( 'Subscription successfully created.	order is %s', 'sdevs_subscrpt' ),
+					__( 'Subscription successfully created.	order is %s', 'wp_subscription' ),
 					$order_item->get_order_id()
 				),
 				'comment_post_ID' => $subscription_id,
 				'comment_type'    => 'order_note',
 			)
 		);
-		update_comment_meta( $comment_id, '_subscrpt_activity', __( 'New Subscription', 'sdevs_subscrpt' ) );
+		update_comment_meta( $comment_id, '_subscrpt_activity', __( 'New Subscription', 'wp_subscription' ) );
 
 		update_post_meta( $subscription_id, '_subscrpt_product_id', $product->get_id() );
 
@@ -562,7 +562,7 @@ class Helper {
 		$old_order = wc_get_order( $old_order_id );
 		if ( ! $old_order || 'completed' !== $old_order->get_status() ) {
 			if ( ! is_admin() && function_exists( 'wc_add_notice' ) ) {
-				return wc_add_notice( __( 'Subscription renewal isn\'t possible due to previous order not completed or deletion.', 'sdevs_subscrpt' ), 'error' );
+				return wc_add_notice( __( 'Subscription renewal isn\'t possible due to previous order not completed or deletion.', 'wp_subscription' ), 'error' );
 			}
 			return false;
 		}

--- a/includes/Illuminate/Order.php
+++ b/includes/Illuminate/Order.php
@@ -80,7 +80,7 @@ class Order {
 	 */
 	public function register_custom_column() {
 		?>
-		<th class="item_recurring sortable" data-sort="float"><?php esc_html_e( 'Recurring', 'sdevs_subscrpt' ); ?></th>
+		<th class="item_recurring sortable" data-sort="float"><?php esc_html_e( 'Recurring', 'wp_subscription' ); ?></th>
 		<?php
 	}
 

--- a/includes/Illuminate/Post.php
+++ b/includes/Illuminate/Post.php
@@ -24,17 +24,17 @@ class Post {
 	 */
 	public function update_post_labels( $messages ) {
 		$messages['subscrpt_order'] = array(
-			__( 'Subscription updated.', 'sdevs_subscrpt' ),
-			__( 'Subscription updated.', 'sdevs_subscrpt' ),
+			__( 'Subscription updated.', 'wp_subscription' ),
+			__( 'Subscription updated.', 'wp_subscription' ),
 			'Custom field updated.',
 			'Custom field deleted.',
-			__( 'Subscription updated.', 'sdevs_subscrpt' ),
+			__( 'Subscription updated.', 'wp_subscription' ),
 			false,
-			__( 'Subscription published.', 'sdevs_subscrpt' ),
-			__( 'Subscription saved.', 'sdevs_subscrpt' ),
-			__( 'Subscription submitted.', 'sdevs_subscrpt' ),
+			__( 'Subscription published.', 'wp_subscription' ),
+			__( 'Subscription saved.', 'wp_subscription' ),
+			__( 'Subscription submitted.', 'wp_subscription' ),
 			false,
-			__( 'Subscription draft updated.', 'sdevs_subscrpt' ),
+			__( 'Subscription draft updated.', 'wp_subscription' ),
 		);
 		return $messages;
 	}
@@ -55,27 +55,27 @@ class Post {
 	 */
 	public function register_subscription_post_type() {
 		$labels = array(
-			'name'              => __( 'Subscriptions', 'sdevs_subscrpt' ),
-			'singular_name'     => __( 'Subscription', 'sdevs_subscrpt' ),
-			'name_admin_bar'    => __( 'Subscription\'s', 'sdevs_subscrpt' ),
-			'archives'          => __( 'Item Archives', 'sdevs_subscrpt' ),
-			'attributes'        => __( 'Item Attributes', 'sdevs_subscrpt' ),
-			'parent_item_colon' => __( 'Parent :', 'sdevs_subscrpt' ),
-			'all_items'         => __( 'Subscriptions', 'sdevs_subscrpt' ),
-			'add_new_item'      => __( 'Add New Subscription', 'sdevs_subscrpt' ),
-			'add_new'           => __( 'Add Subscription', 'sdevs_subscrpt' ),
-			'new_item'          => __( 'New Subscription', 'sdevs_subscrpt' ),
-			'edit_item'         => __( 'Edit Subscription', 'sdevs_subscrpt' ),
-			'update_item'       => __( 'Update Subscription', 'sdevs_subscrpt' ),
-			'view_item'         => __( 'View Subscription', 'sdevs_subscrpt' ),
-			'view_items'        => __( 'View Subscription', 'sdevs_subscrpt' ),
-			'search_items'      => __( 'Search Subscription', 'sdevs_subscrpt' ),
-			'not_found'         => __( 'No subscriptions found.', 'sdevs_subscrpt' ),
-			'item_updated'      => __( 'Subscription updated.', 'sdevs_subscrpt' ),
+			'name'              => __( 'Subscriptions', 'wp_subscription' ),
+			'singular_name'     => __( 'Subscription', 'wp_subscription' ),
+			'name_admin_bar'    => __( 'Subscription\'s', 'wp_subscription' ),
+			'archives'          => __( 'Item Archives', 'wp_subscription' ),
+			'attributes'        => __( 'Item Attributes', 'wp_subscription' ),
+			'parent_item_colon' => __( 'Parent :', 'wp_subscription' ),
+			'all_items'         => __( 'Subscriptions', 'wp_subscription' ),
+			'add_new_item'      => __( 'Add New Subscription', 'wp_subscription' ),
+			'add_new'           => __( 'Add Subscription', 'wp_subscription' ),
+			'new_item'          => __( 'New Subscription', 'wp_subscription' ),
+			'edit_item'         => __( 'Edit Subscription', 'wp_subscription' ),
+			'update_item'       => __( 'Update Subscription', 'wp_subscription' ),
+			'view_item'         => __( 'View Subscription', 'wp_subscription' ),
+			'view_items'        => __( 'View Subscription', 'wp_subscription' ),
+			'search_items'      => __( 'Search Subscription', 'wp_subscription' ),
+			'not_found'         => __( 'No subscriptions found.', 'wp_subscription' ),
+			'item_updated'      => __( 'Subscription updated.', 'wp_subscription' ),
 		);
 
 		$args = array(
-			'label'                 => __( 'Subscriptions', 'sdevs_subscrpt' ),
+			'label'                 => __( 'Subscriptions', 'wp_subscription' ),
 			'labels'                => $labels,
 			'description'           => '',
 			'public'                => false,
@@ -113,7 +113,7 @@ class Post {
 	 */
 	public function register_subscription_item_post_type() {
 		$args = array(
-			'label'                 => __( 'Subscription Items', 'sdevs_subscrpt' ),
+			'label'                 => __( 'Subscription Items', 'wp_subscription' ),
 			// 'labels'                => ,
 			'description'           => '',
 			'public'                => false,
@@ -155,10 +155,10 @@ class Post {
 		register_post_status(
 			'pending',
 			array(
-				'label'                     => _x( 'Pending', 'post status label', 'sdevs_subscrpt' ),
+				'label'                     => _x( 'Pending', 'post status label', 'wp_subscription' ),
 				'public'                    => true,
 				// translators: pending posts count.
-				'label_count'               => _n_noop( 'Pending <span class="count">(%s)</span>', 'Pending <span class="count">(%s)</span>', 'sdevs_subscrpt' ),
+				'label_count'               => _n_noop( 'Pending <span class="count">(%s)</span>', 'Pending <span class="count">(%s)</span>', 'wp_subscription' ),
 				'post_type'                 => array( 'subscrpt_order' ),
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
@@ -171,10 +171,10 @@ class Post {
 		register_post_status(
 			'active',
 			array(
-				'label'                     => _x( 'Active', 'post status label', 'sdevs_subscrpt' ),
+				'label'                     => _x( 'Active', 'post status label', 'wp_subscription' ),
 				'public'                    => true,
 				// translators: active posts count.
-				'label_count'               => _n_noop( 'Active <span class="count">(%s)</span>', 'Active <span class="count">(%s)</span>', 'sdevs_subscrpt' ),
+				'label_count'               => _n_noop( 'Active <span class="count">(%s)</span>', 'Active <span class="count">(%s)</span>', 'wp_subscription' ),
 				'post_type'                 => array( 'subscrpt_order' ),
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
@@ -187,10 +187,10 @@ class Post {
 		register_post_status(
 			'on_hold',
 			array(
-				'label'                     => _x( 'On Hold', 'post status label', 'sdevs_subscrpt' ),
+				'label'                     => _x( 'On Hold', 'post status label', 'wp_subscription' ),
 				'public'                    => true,
 				// translators: on-hold posts count.
-				'label_count'               => _n_noop( 'On Hold <span class="count">(%s)</span>', 'On Hold <span class="count">(%s)</span>', 'sdevs_subscrpt' ),
+				'label_count'               => _n_noop( 'On Hold <span class="count">(%s)</span>', 'On Hold <span class="count">(%s)</span>', 'wp_subscription' ),
 				'post_type'                 => array( 'subscrpt_order' ),
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
@@ -203,10 +203,10 @@ class Post {
 		register_post_status(
 			'cancelled',
 			array(
-				'label'                     => _x( 'Cancelled', 'post status label', 'sdevs_subscrpt' ),
+				'label'                     => _x( 'Cancelled', 'post status label', 'wp_subscription' ),
 				'public'                    => true,
 				// translators: cancelled posts count.
-				'label_count'               => _n_noop( 'Cancelled <span class="count">(%s)</span>', 'Cancelled <span class="count">(%s)</span>', 'sdevs_subscrpt' ),
+				'label_count'               => _n_noop( 'Cancelled <span class="count">(%s)</span>', 'Cancelled <span class="count">(%s)</span>', 'wp_subscription' ),
 				'post_type'                 => array( 'subscrpt_order' ),
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
@@ -219,10 +219,10 @@ class Post {
 		register_post_status(
 			'expired',
 			array(
-				'label'                     => _x( 'Expired', 'post status label', 'sdevs_subscrpt' ),
+				'label'                     => _x( 'Expired', 'post status label', 'wp_subscription' ),
 				'public'                    => true,
 				// translators: expired posts count.
-				'label_count'               => _n_noop( 'Expired <span class="count">(%s)</span>', 'Expired <span class="count">(%s)</span>', 'sdevs_subscrpt' ),
+				'label_count'               => _n_noop( 'Expired <span class="count">(%s)</span>', 'Expired <span class="count">(%s)</span>', 'wp_subscription' ),
 				'post_type'                 => array( 'subscrpt_order' ),
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
@@ -235,10 +235,10 @@ class Post {
 		register_post_status(
 			'pe_cancelled',
 			array(
-				'label'                     => _x( 'Pending Cancellation', 'post status label', 'sdevs_subscrpt' ),
+				'label'                     => _x( 'Pending Cancellation', 'post status label', 'wp_subscription' ),
 				'public'                    => true,
 				// translators: pending cancellation posts count.
-				'label_count'               => _n_noop( 'Pending Cancellation <span class="count">(%s)</span>', 'Pending Cancellation <span class="count">(%s)</span>', 'sdevs_subscrpt' ),
+				'label_count'               => _n_noop( 'Pending Cancellation <span class="count">(%s)</span>', 'Pending Cancellation <span class="count">(%s)</span>', 'wp_subscription' ),
 				'post_type'                 => array( 'subscrpt_order' ),
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,

--- a/includes/Illuminate/Stripe.php
+++ b/includes/Illuminate/Stripe.php
@@ -53,7 +53,7 @@ class Stripe extends \WC_Stripe_Payment_Gateway {
 			// Get source from order.
 			$prepared_source = $this->prepare_order_source( $renewal_order );
 			if ( ! $prepared_source->customer ) {
-				return new \WP_Error( 'stripe_error', __( 'Customer not found', 'sdevs_subscrpt' ) );
+				return new \WP_Error( 'stripe_error', __( 'Customer not found', 'wp_subscription' ) );
 			}
 
 			\WC_Stripe_Logger::log( "Info: Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );

--- a/includes/Illuminate/views/subscription-table.php
+++ b/includes/Illuminate/views/subscription-table.php
@@ -18,7 +18,7 @@ use SpringDevs\Subscription\Illuminate\Helper;
 		<tr>
 			<h2>
 			<?php
-				esc_html_e( 'Related Subscriptions', 'sdevs_subscrpt' );
+				esc_html_e( 'Related Subscriptions', 'wp_subscription' );
 			?>
 				</h2>
 			<?php
@@ -52,21 +52,21 @@ use SpringDevs\Subscription\Illuminate\Helper;
 			</tr>
 			<tr>
 				<th class="td" scope="row" colspan="2"
-					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'Status:', 'sdevs_subscrpt' ); ?> </th>
+					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'Status:', 'wp_subscription' ); ?> </th>
 				<td class="td"
 					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php echo esc_html( $subscription_status_object->label ); ?></td>
 			</tr>
 			<tr>
 				<th class="td" scope="row" colspan="2"
 					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;">
-					<?php esc_html_e( 'Recurring amount:', 'sdevs_subscrpt' ); ?> </th>
+					<?php esc_html_e( 'Recurring amount:', 'wp_subscription' ); ?> </th>
 				<td class="td"
 					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php echo wp_kses_post( Helper::format_price_with_order_item( $cost, $item->get_id() ) ); ?></td>
 			</tr>
 			<?php if ( ! $has_trial ) { ?>
 			<tr>
 				<th class="td" scope="row" colspan="2"
-					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'Next billing on', 'sdevs_subscrpt' ); ?>
+					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'Next billing on', 'wp_subscription' ); ?>
 					:
 				</th>
 				<td class="td"
@@ -75,7 +75,7 @@ use SpringDevs\Subscription\Illuminate\Helper;
 		<?php } else { ?>
 			<tr>
 				<th class="td" scope="row" colspan="2"
-					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'Trial', 'sdevs_subscrpt' ); ?>
+					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'Trial', 'wp_subscription' ); ?>
 					:
 				</th>
 				<td class="td"
@@ -83,7 +83,7 @@ use SpringDevs\Subscription\Illuminate\Helper;
 			</tr>
 			<tr>
 				<th class="td" scope="row" colspan="2"
-					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'First billing on', 'sdevs_subscrpt' ); ?>
+					style="color: #636363; border: 1px solid #e5e5e5; vertical-align: middle; padding: 12px; text-align: left;"><?php esc_html_e( 'First billing on', 'wp_subscription' ); ?>
 					:
 				</th>
 				<td class="td"

--- a/includes/Traits/Email.php
+++ b/includes/Traits/Email.php
@@ -92,7 +92,7 @@ trait Email {
 	 * @since  3.1.0
 	 */
 	public function get_default_heading(): string {
-		return __( 'Subscription: #{subscription_id}', 'sdevs_subscrpt' );
+		return __( 'Subscription: #{subscription_id}', 'wp_subscription' );
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -28,13 +28,13 @@ function subscrpt_get_action_url( $action, $nonce, $subscription_id ) {
 
 function subscrpt_get_typos( $number, $typo ) {
 	if ( $number == 1 && $typo == 'days' ) {
-		return __( 'day', 'sdevs_subscrpt' );
+		return __( 'day', 'wp_subscription' );
 	} elseif ( $number == 1 && $typo == 'weeks' ) {
-		return __( 'week', 'sdevs_subscrpt' );
+		return __( 'week', 'wp_subscription' );
 	} elseif ( $number == 1 && $typo == 'months' ) {
-		return __( 'month', 'sdevs_subscrpt' );
+		return __( 'month', 'wp_subscription' );
 	} elseif ( $number == 1 && $typo == 'years' ) {
-		return __( 'year', 'sdevs_subscrpt' );
+		return __( 'year', 'wp_subscription' );
 	} else {
 		return $typo;
 	}
@@ -87,8 +87,8 @@ function order_relation_type_cast( string $key ) {
 	$relational_type_keys = apply_filters(
 		'subscrpt_order_relational_types',
 		array(
-			'new'   => __( 'New Subscription Order', 'sdevs_subscrpt' ),
-			'renew' => __( 'Renewal Order', 'sdevs_subscrpt' ),
+			'new'   => __( 'New Subscription Order', 'wp_subscription' ),
+			'renew' => __( 'Renewal Order', 'wp_subscription' ),
 		)
 	);
 
@@ -153,19 +153,19 @@ if ( ! function_exists( 'get_timing_types' ) ) {
 			'years'  => 'Yearly',
 		) : array(
 			array(
-				'label' => __( 'day(s)', 'sdevs_subscrpt' ),
+				'label' => __( 'day(s)', 'wp_subscription' ),
 				'value' => 'days',
 			),
 			array(
-				'label' => __( 'week(s)', 'sdevs_subscrpt' ),
+				'label' => __( 'week(s)', 'wp_subscription' ),
 				'value' => 'weeks',
 			),
 			array(
-				'label' => __( 'month(s)', 'sdevs_subscrpt' ),
+				'label' => __( 'month(s)', 'wp_subscription' ),
 				'value' => 'months',
 			),
 			array(
-				'label' => __( 'year(s)', 'sdevs_subscrpt' ),
+				'label' => __( 'year(s)', 'wp_subscription' ),
 				'value' => 'years',
 			),
 		);

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 import {
-	registerCheckoutFilters,
-	ExperimentalOrderMeta,
-	TotalsItem,
+    ExperimentalOrderMeta,
+    registerCheckoutFilters,
+    TotalsItem,
 } from '@woocommerce/blocks-checkout';
 import { FormattedMonetaryAmount } from '@woocommerce/blocks-components';
-import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
 
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 // import { useStoreCart } from "@woocommerce/base-context/hooks";
@@ -65,7 +65,7 @@ const RecurringTotals = ( { cart, extensions } ) => {
 	return (
 		<TotalsItem
 			className="wc-block-components-totals-footer-item"
-			label={ __( 'Recurring totals', 'sdevs_subscrpt' ) }
+			label={ __( 'Recurring totals', 'wp_subscription' ) }
 			description={
 				<div style={ { display: 'grid' } }>
 					{ recurrings.map( ( recurring ) => (

--- a/templates/emails/plains/renew-reminder-plain.php
+++ b/templates/emails/plains/renew-reminder-plain.php
@@ -13,23 +13,23 @@
 echo esc_html( '= ' . $email_heading . " =\n\n" );
 
 // translators: first is older status and last is newly updated status.
-$opening_paragraph = __( 'You have only %1$s %2$s left! Please renew the subscription before expired', 'sdevs_subscrpt' );
+$opening_paragraph = __( 'You have only %1$s %2$s left! Please renew the subscription before expired', 'wp_subscription' );
 
 echo wp_kses_post( sprintf( $opening_paragraph, $num_of_days_before, $num_of_days_before > 1 ? 'days' : 'day' ) . "\n\n" );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 // translators: Subscription id.
-echo esc_html( sprintf( __( 'Subscription Id: %s', 'sdevs_subscrpt' ), $id ) . "\n" );
+echo esc_html( sprintf( __( 'Subscription Id: %s', 'wp_subscription' ), $id ) . "\n" );
 
 // translators: Product name.
-echo esc_html( sprintf( __( 'Product: %s', 'sdevs_subscrpt' ), $product_name ) . "\n" );
+echo esc_html( sprintf( __( 'Product: %s', 'wp_subscription' ), $product_name ) . "\n" );
 
 // translators: Subscription quantity.
-echo esc_html( sprintf( __( 'Qty: %s', 'sdevs_subscrpt' ), $qty ) . "\n" );
+echo esc_html( sprintf( __( 'Qty: %s', 'wp_subscription' ), $qty ) . "\n" );
 
 // translators: Subscription amount.
-echo wp_kses_post( sprintf( __( 'Amount: %s', 'sdevs_subscrpt' ), $amount ) . "\n" );
+echo wp_kses_post( sprintf( __( 'Amount: %s', 'wp_subscription' ), $amount ) . "\n" );
 
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
@@ -38,7 +38,7 @@ echo wp_kses_post(
 	make_clickable(
 		sprintf(
 		// translators: subscription id.
-			__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+			__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 			admin_url( 'post.php?post=' . $id . '&action=edit' )
 		)
 	)

--- a/templates/emails/plains/status-changed-admin-plain.php
+++ b/templates/emails/plains/status-changed-admin-plain.php
@@ -15,23 +15,23 @@
 echo esc_html( '= ' . $email_heading . " =\n\n" );
 
 // translators: first is older status and last is newly updated status.
-$opening_paragraph = __( 'Subscription status changed from %1$s to %2$s', 'sdevs_subscrpt' );
+$opening_paragraph = __( 'Subscription status changed from %1$s to %2$s', 'wp_subscription' );
 
 echo esc_html( sprintf( $opening_paragraph, $old_status, $new_status ) . "\n\n" );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 // translators: Subscription id.
-echo esc_html( sprintf( __( 'Subscription Id: %s', 'sdevs_subscrpt' ), $id ) . "\n" );
+echo esc_html( sprintf( __( 'Subscription Id: %s', 'wp_subscription' ), $id ) . "\n" );
 
 // translators: Product name.
-echo esc_html( sprintf( __( 'Product: %s', 'sdevs_subscrpt' ), $product_name ) . "\n" );
+echo esc_html( sprintf( __( 'Product: %s', 'wp_subscription' ), $product_name ) . "\n" );
 
 // translators: Subscription quantity.
-echo esc_html( sprintf( __( 'Qty: %s', 'sdevs_subscrpt' ), $qty ) . "\n" );
+echo esc_html( sprintf( __( 'Qty: %s', 'wp_subscription' ), $qty ) . "\n" );
 
 // translators: Subscription amount.
-echo wp_kses_post( sprintf( __( 'Amount: %s', 'sdevs_subscrpt' ), $amount ) . "\n" );
+echo wp_kses_post( sprintf( __( 'Amount: %s', 'wp_subscription' ), $amount ) . "\n" );
 
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
@@ -40,7 +40,7 @@ echo wp_kses_post(
 	make_clickable(
 		sprintf(
 		// translators: subscription id.
-			__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+			__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 			admin_url( 'post.php?post=' . $id . '&action=edit' )
 		)
 	)

--- a/templates/emails/plains/subscription-cancelled-plain.php
+++ b/templates/emails/plains/subscription-cancelled-plain.php
@@ -12,23 +12,23 @@
 echo esc_html( '= ' . $email_heading . " =\n\n" );
 
 // translators: first is older status and last is newly updated status.
-$opening_paragraph = __( 'Your subscription is %1$s Cancelled! %2$s', 'sdevs_subscrpt' );
+$opening_paragraph = __( 'Your subscription is %1$s Cancelled! %2$s', 'wp_subscription' );
 
 echo wp_kses_post( sprintf( $opening_paragraph, '<b>', '</b>' ) . "\n\n" );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 // translators: Subscription id.
-echo esc_html( sprintf( __( 'Subscription Id: %s', 'sdevs_subscrpt' ), $id ) . "\n" );
+echo esc_html( sprintf( __( 'Subscription Id: %s', 'wp_subscription' ), $id ) . "\n" );
 
 // translators: Product name.
-echo esc_html( sprintf( __( 'Product: %s', 'sdevs_subscrpt' ), $product_name ) . "\n" );
+echo esc_html( sprintf( __( 'Product: %s', 'wp_subscription' ), $product_name ) . "\n" );
 
 // translators: Subscription quantity.
-echo esc_html( sprintf( __( 'Qty: %s', 'sdevs_subscrpt' ), $qty ) . "\n" );
+echo esc_html( sprintf( __( 'Qty: %s', 'wp_subscription' ), $qty ) . "\n" );
 
 // translators: Subscription amount.
-echo wp_kses_post( sprintf( __( 'Amount: %s', 'sdevs_subscrpt' ), $amount ) . "\n" );
+echo wp_kses_post( sprintf( __( 'Amount: %s', 'wp_subscription' ), $amount ) . "\n" );
 
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
@@ -37,7 +37,7 @@ echo wp_kses_post(
 	make_clickable(
 		sprintf(
 		// translators: subscription id.
-			__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+			__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 			admin_url( 'post.php?post=' . $id . '&action=edit' )
 		)
 	)

--- a/templates/emails/plains/subscription-expired-plain.php
+++ b/templates/emails/plains/subscription-expired-plain.php
@@ -12,23 +12,23 @@
 echo esc_html( '= ' . $email_heading . " =\n\n" );
 
 // translators: first is older status and last is newly updated status.
-$opening_paragraph = __( 'Your subscription is %1$s Expired! %2$s', 'sdevs_subscrpt' );
+$opening_paragraph = __( 'Your subscription is %1$s Expired! %2$s', 'wp_subscription' );
 
 echo wp_kses_post( sprintf( $opening_paragraph, '<b>', '</b>' ) . "\n\n" );
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 // translators: Subscription id.
-echo esc_html( sprintf( __( 'Subscription Id: %s', 'sdevs_subscrpt' ), $id ) . "\n" );
+echo esc_html( sprintf( __( 'Subscription Id: %s', 'wp_subscription' ), $id ) . "\n" );
 
 // translators: Product name.
-echo esc_html( sprintf( __( 'Product: %s', 'sdevs_subscrpt' ), $product_name ) . "\n" );
+echo esc_html( sprintf( __( 'Product: %s', 'wp_subscription' ), $product_name ) . "\n" );
 
 // translators: Subscription quantity.
-echo esc_html( sprintf( __( 'Qty: %s', 'sdevs_subscrpt' ), $qty ) . "\n" );
+echo esc_html( sprintf( __( 'Qty: %s', 'wp_subscription' ), $qty ) . "\n" );
 
 // translators: Subscription amount.
-echo wp_kses_post( sprintf( __( 'Amount: %s', 'sdevs_subscrpt' ), $amount ) . "\n" );
+echo wp_kses_post( sprintf( __( 'Amount: %s', 'wp_subscription' ), $amount ) . "\n" );
 
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
@@ -37,7 +37,7 @@ echo wp_kses_post(
 	make_clickable(
 		sprintf(
 		// translators: subscription id.
-			__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+			__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 			admin_url( 'post.php?post=' . $id . '&action=edit' )
 		)
 	)

--- a/templates/emails/renew-reminder-html.php
+++ b/templates/emails/renew-reminder-html.php
@@ -17,26 +17,26 @@
 <p>
 <?php
 // translators: Number of days before & day|days.
-echo esc_html( sprintf( __( 'You have only %1$s %2$s left! Please renew the subscription before expired', 'sdevs_subscrpt' ), $num_of_days_before, $num_of_days_before > 1 ? 'days' : 'day' ) );
+echo esc_html( sprintf( __( 'You have only %1$s %2$s left! Please renew the subscription before expired', 'wp_subscription' ), $num_of_days_before, $num_of_days_before > 1 ? 'days' : 'day' ) );
 ?>
 </p>
 
 <table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
 	<tbody>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $id ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $product_name ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $qty ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo wp_kses_post( $amount ); ?></td>
 	</tr>
 	</tbody>
@@ -48,7 +48,7 @@ echo esc_html( sprintf( __( 'You have only %1$s %2$s left! Please renew the subs
 		make_clickable(
 			sprintf(
 			// translators: subscription id.
-				__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+				__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 				admin_url( 'post.php?post=' . $id . '&action=edit' )
 			)
 		)

--- a/templates/emails/status-changed-admin-html.php
+++ b/templates/emails/status-changed-admin-html.php
@@ -13,7 +13,7 @@
  */
 
 // translators: first is older status and last is newly updated status.
-$opening_paragraph = __( 'Subscription status changed from %1$s to %2$s', 'sdevs_subscrpt' );
+$opening_paragraph = __( 'Subscription status changed from %1$s to %2$s', 'wp_subscription' );
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
@@ -24,19 +24,19 @@ $opening_paragraph = __( 'Subscription status changed from %1$s to %2$s', 'sdevs
 <table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
 	<tbody>
 		<tr>
-			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'sdevs_subscrpt' ); ?></th>
+			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'wp_subscription' ); ?></th>
 			<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $id ); ?></td>
 		</tr>
 		<tr>
-			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'sdevs_subscrpt' ); ?></th>
+			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'wp_subscription' ); ?></th>
 			<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $product_name ); ?></td>
 		</tr>
 		<tr>
-			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'sdevs_subscrpt' ); ?></th>
+			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'wp_subscription' ); ?></th>
 			<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $qty ); ?></td>
 		</tr>
 		<tr>
-			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'sdevs_subscrpt' ); ?></th>
+			<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'wp_subscription' ); ?></th>
 			<td style="text-align:left; border: 1px solid #eee;"><?php echo wp_kses_post( $amount ); ?></td>
 		</tr>
 </tbody>
@@ -48,7 +48,7 @@ echo wp_kses_post(
 	make_clickable(
 		sprintf(
 			// translators: subscription id.
-			__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+			__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 			admin_url( 'post.php?post=' . $id . '&action=edit' )
 		)
 	)

--- a/templates/emails/subscription-cancelled-html.php
+++ b/templates/emails/subscription-cancelled-html.php
@@ -16,26 +16,26 @@
 <p>
 	<?php
 	// translators: <b></b> tag.
-	echo wp_kses_post( sprintf( __( 'Your subscription is %1$s Cancelled! %2$s', 'sdevs_subscrpt' ), '<b>', '</b>' ) );
+	echo wp_kses_post( sprintf( __( 'Your subscription is %1$s Cancelled! %2$s', 'wp_subscription' ), '<b>', '</b>' ) );
 	?>
 </p>
 
 <table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
 	<tbody>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $id ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $product_name ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $qty ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo wp_kses_post( $amount ); ?></td>
 	</tr>
 	</tbody>
@@ -47,7 +47,7 @@
 		make_clickable(
 			sprintf(
 			// translators: subscription id.
-				__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+				__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 				admin_url( 'post.php?post=' . $id . '&action=edit' )
 			)
 		)

--- a/templates/emails/subscription-expired-html.php
+++ b/templates/emails/subscription-expired-html.php
@@ -16,26 +16,26 @@
 <p>
 <?php
 // translators: <b></b> tag.
-echo wp_kses_post( sprintf( __( 'Your subscription is %1$s Expired! %2$s', 'sdevs_subscrpt' ), '<b>', '</b>' ) );
+echo wp_kses_post( sprintf( __( 'Your subscription is %1$s Expired! %2$s', 'wp_subscription' ), '<b>', '</b>' ) );
 ?>
 </p>
 
 <table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
 	<tbody>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Subscription Id', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $id ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $product_name ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Qty', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo esc_html( $qty ); ?></td>
 	</tr>
 	<tr>
-		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'sdevs_subscrpt' ); ?></th>
+		<th scope="row" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Amount', 'wp_subscription' ); ?></th>
 		<td style="text-align:left; border: 1px solid #eee;"><?php echo wp_kses_post( $amount ); ?></td>
 	</tr>
 	</tbody>
@@ -47,7 +47,7 @@ echo wp_kses_post( sprintf( __( 'Your subscription is %1$s Expired! %2$s', 'sdev
 		make_clickable(
 			sprintf(
 			// translators: subscription id.
-				__( 'You can view and edit this subscription in the dashboard here: %s', 'sdevs_subscrpt' ),
+				__( 'You can view and edit this subscription in the dashboard here: %s', 'wp_subscription' ),
 				admin_url( 'post.php?post=' . $id . '&action=edit' )
 			)
 		)

--- a/templates/myaccount/single.php
+++ b/templates/myaccount/single.php
@@ -43,28 +43,28 @@ do_action( 'before_single_subscrpt_content' );
 <table class="woocommerce-table woocommerce-table--order-details shop_table order_details subscription_details">
 	<tbody>
 		<tr>
-			<td><?php esc_html_e( 'Order', 'sdevs_subscrpt' ); ?></td>
+			<td><?php esc_html_e( 'Order', 'wp_subscription' ); ?></td>
 			<td><a href="<?php echo esc_html( wc_get_endpoint_url( 'view-order', $order->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" target="_blank"># <?php echo esc_html( $order->get_id() ); ?></a></td>
 		</tr>
 		<tr>
-			<td><?php esc_html_e( 'Status', 'sdevs_subscrpt' ); ?></td>
+			<td><?php esc_html_e( 'Status', 'wp_subscription' ); ?></td>
 			<td><span class="subscrpt-<?php echo esc_html( $status->name ); ?>"><?php echo esc_html( $status->label ); ?></span></td>
 		</tr>
 		<?php if ( null != $trial && 'off' !== $trial ) : ?>
 		<tr>
-			<td><?php esc_html_e( 'Trial', 'sdevs_subscrpt' ); ?></td>
+			<td><?php esc_html_e( 'Trial', 'wp_subscription' ); ?></td>
 			<td><?php echo esc_html( $trial ); ?></td>
 		</tr>
 		<?php endif; ?>
 		<tr>
-			<td><?php esc_html_e( ( 'null' == $trial || 'off' === $trial_mode ? 'Start date' : ( 'extended' === $trial_mode ? 'Trial End & Subscription Start' : 'Trial End & First Billing' ) ), 'sdevs_subscrpt' ); ?></td>
+			<td><?php esc_html_e( ( 'null' == $trial || 'off' === $trial_mode ? 'Start date' : ( 'extended' === $trial_mode ? 'Trial End & Subscription Start' : 'Trial End & First Billing' ) ), 'wp_subscription' ); ?></td>
 			<td><?php echo esc_html( ! empty( $start_date ) ? gmdate( 'F d, Y', $start_date ) : '-' ); ?></td>
 		</tr>
 		<?php if ( null == $trial || in_array( $trial_mode, array( 'off', 'extended' ), true ) ) : ?>
 			<tr>
 				<td>
 				<?php
-					esc_html_e( 'Next payment date', 'sdevs_subscrpt' );
+					esc_html_e( 'Next payment date', 'wp_subscription' );
 				?>
 				</td>
 				<td>
@@ -74,7 +74,7 @@ do_action( 'before_single_subscrpt_content' );
 		<?php endif; ?>
 		<?php if ( ! empty( $order->get_payment_method_title() ) ) : ?>
 		<tr>
-			<td><?php esc_html_e( 'Payment', 'sdevs_subscrpt' ); ?></td>
+			<td><?php esc_html_e( 'Payment', 'wp_subscription' ); ?></td>
 			<td>
 				<span data-is_manual="yes" class="subscription-payment-method"><?php echo esc_html( $order->get_payment_method_title() ); ?></span>
 			</td>
@@ -82,7 +82,7 @@ do_action( 'before_single_subscrpt_content' );
 		<?php endif; ?>
 		<?php if ( 0 < count( $action_buttons ) ) : ?>
 			<tr>
-				<td><?php echo esc_html_e( 'Actions', 'sdevs_subscrpt' ); ?></td>
+				<td><?php echo esc_html_e( 'Actions', 'wp_subscription' ); ?></td>
 				<td class="subscrpt_action_buttons">
 					<?php foreach ( $action_buttons as $action_button ) : ?>
 						<a href="<?php echo esc_attr( $action_button['url'] ); ?>" class="button
@@ -100,12 +100,12 @@ do_action( 'before_single_subscrpt_content' );
 
 <?php do_action( 'subscrpt_before_subscription_totals', (int) $id ); ?>
 
-<h2><?php echo esc_html_e( 'Subscription Totals', 'sdevs_subscrpt' ); ?></h2>
+<h2><?php echo esc_html_e( 'Subscription Totals', 'wp_subscription' ); ?></h2>
 <table class="woocommerce-table woocommerce-table--order-details shop_table order_details">
 	<thead>
 		<tr>
-			<th class="product-name"><?php echo esc_html_e( 'Product', 'sdevs_subscrpt' ); ?></th>
-			<th class="product-total"><?php echo esc_html_e( 'Total', 'sdevs_subscrpt' ); ?></th>
+			<th class="product-name"><?php echo esc_html_e( 'Product', 'wp_subscription' ); ?></th>
+			<th class="product-total"><?php echo esc_html_e( 'Total', 'wp_subscription' ); ?></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -133,13 +133,13 @@ do_action( 'before_single_subscrpt_content' );
 	</tbody>
 	<tfoot>
 		<tr>
-			<th scope="row"><?php esc_html_e( 'Subtotal', 'sdevs_subscrpt' ); ?>:</th>
+			<th scope="row"><?php esc_html_e( 'Subtotal', 'wp_subscription' ); ?>:</th>
 			<td>
 				<span class="woocommerce-Price-amount amount"><?php echo wp_kses_post( wc_price( get_post_meta( $id, '_subscrpt_price', true ), array( 'currency' => $order->get_currency() ) ) ); ?></span>
 			</td>
 		</tr>
 		<tr>
-			<th scope="row"><?php esc_html_e( 'Renew', 'sdevs_subscrpt' ); ?>:</th>
+			<th scope="row"><?php esc_html_e( 'Renew', 'wp_subscription' ); ?>:</th>
 			<td>
 				<span class="woocommerce-Price-amount amount">
 					<?php echo wp_kses_post( $product_price_html ); ?>
@@ -152,7 +152,7 @@ do_action( 'before_single_subscrpt_content' );
 <?php do_action( 'subscrpt_after_subscription_totals', (int) $id ); ?>
 
 <section class="woocommerce-customer-details">
-	<h2 class="woocommerce-column__title"><?php esc_html_e( 'Billing address', 'sdevs_subscrpt' ); ?></h2>
+	<h2 class="woocommerce-column__title"><?php esc_html_e( 'Billing address', 'wp_subscription' ); ?></h2>
 	<address>
 		<?php echo wp_kses_post( $order->get_formatted_billing_address() ); ?>
 		<p class="woocommerce-customer-details--phone"><?php echo esc_html( $order->get_billing_phone() ); ?></p>

--- a/templates/myaccount/subscriptions.php
+++ b/templates/myaccount/subscriptions.php
@@ -14,11 +14,11 @@ use SpringDevs\Subscription\Illuminate\Helper;
 <table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table my_account_subscrpt">
 	<thead>
 		<tr>
-			<th scope="col" class="subscrpt-id"><?php esc_html_e( 'Subscription', 'sdevs_subscrpt' ); ?></th>
-			<th scope="col" class="order-status"><?php esc_html_e( 'Status', 'sdevs_subscrpt' ); ?></th>
-			<th scope="col" class="order-product"><?php esc_html_e( 'Product', 'sdevs_subscrpt' ); ?></th>
-			<th scope="col" class="subscrpt-next-date"><?php esc_html_e( 'Next Payment', 'sdevs_subscrpt' ); ?></th>
-			<th scope="col" class="subscrpt-total"><?php esc_html_e( 'Total', 'sdevs_subscrpt' ); ?></th>
+			<th scope="col" class="subscrpt-id"><?php esc_html_e( 'Subscription', 'wp_subscription' ); ?></th>
+			<th scope="col" class="order-status"><?php esc_html_e( 'Status', 'wp_subscription' ); ?></th>
+			<th scope="col" class="order-product"><?php esc_html_e( 'Product', 'wp_subscription' ); ?></th>
+			<th scope="col" class="subscrpt-next-date"><?php esc_html_e( 'Next Payment', 'wp_subscription' ); ?></th>
+			<th scope="col" class="subscrpt-total"><?php esc_html_e( 'Total', 'wp_subscription' ); ?></th>
 			<th scope="col" class="subscrpt-action"></th>
 		</tr>
 	</thead>
@@ -65,7 +65,7 @@ use SpringDevs\Subscription\Illuminate\Helper;
 			<tr>
 				<td colspan="6">
 					<p style="text-align: center;">
-						<?php echo esc_html_e( 'No subscriptions available yet.', 'sdevs_subscrpt' ); ?>
+						<?php echo esc_html_e( 'No subscriptions available yet.', 'wp_subscription' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -78,11 +78,11 @@ use SpringDevs\Subscription\Illuminate\Helper;
 <?php if ( 1 < $postslist->max_num_pages ) : ?>
 	<div class="woocommerce-pagination woocommerce-pagination--without-numbers woocommerce-Pagination">
 		<?php if ( 1 !== $current_page ) : ?>
-			<a class="woocommerce-button woocommerce-button--previous woocommerce-Button woocommerce-Button--previous button<?php echo esc_attr( $wp_button_class ); ?>" href="<?php echo esc_url( wc_get_endpoint_url( 'subscriptions', $current_page - 1 ) ); ?>"><?php esc_html_e( 'Previous', 'sdevs_subscrpt' ); ?></a>
+			<a class="woocommerce-button woocommerce-button--previous woocommerce-Button woocommerce-Button--previous button<?php echo esc_attr( $wp_button_class ); ?>" href="<?php echo esc_url( wc_get_endpoint_url( 'subscriptions', $current_page - 1 ) ); ?>"><?php esc_html_e( 'Previous', 'wp_subscription' ); ?></a>
 		<?php endif; ?>
 
 		<?php if ( intval( $postslist->max_num_pages ) !== $current_page ) : ?>
-			<a class="woocommerce-button woocommerce-button--next woocommerce-Button woocommerce-Button--next button<?php echo esc_attr( $wp_button_class ); ?>" href="<?php echo esc_url( wc_get_endpoint_url( 'subscriptions', $current_page + 1 ) ); ?>"><?php esc_html_e( 'Next', 'sdevs_subscrpt' ); ?></a>
+			<a class="woocommerce-button woocommerce-button--next woocommerce-Button woocommerce-Button--next button<?php echo esc_attr( $wp_button_class ); ?>" href="<?php echo esc_url( wc_get_endpoint_url( 'subscriptions', $current_page + 1 ) ); ?>"><?php esc_html_e( 'Next', 'wp_subscription' ); ?></a>
 		<?php endif; ?>
 	</div>
 <?php endif; ?>


### PR DESCRIPTION
This pull request updates the text domain used for translations in subscription-related templates from `sdevs_subscrpt` to `wp_subscription`. This ensures consistency and aligns with the new naming convention for the plugin.

### Text Domain Updates

* Updated the text domain in various labels and strings in `templates/myaccount/single.php`, such as "Order," "Status," "Trial," "Next payment date," "Subscription Totals," and "Billing address." [[1]](diffhunk://#diff-1784eb5b38f7fce2e5715966f66b590d7bc36f1546137d36fc08767ea6f2bdedL46-R67) [[2]](diffhunk://#diff-1784eb5b38f7fce2e5715966f66b590d7bc36f1546137d36fc08767ea6f2bdedL77-R85) [[3]](diffhunk://#diff-1784eb5b38f7fce2e5715966f66b590d7bc36f1546137d36fc08767ea6f2bdedL103-R108) [[4]](diffhunk://#diff-1784eb5b38f7fce2e5715966f66b590d7bc36f1546137d36fc08767ea6f2bdedL136-R142) [[5]](diffhunk://#diff-1784eb5b38f7fce2e5715966f66b590d7bc36f1546137d36fc08767ea6f2bdedL155-R155)
* Updated the text domain in table headers and messages in `templates/myaccount/subscriptions.php`, including "Subscription," "Status," "Product," "Next Payment," "Total," and pagination buttons ("Previous" and "Next"). [[1]](diffhunk://#diff-bfe606005f7adfb6b9a193d1e83bc189dcd1ae1613ac8de4ed393928d7d6790aL17-R21) [[2]](diffhunk://#diff-bfe606005f7adfb6b9a193d1e83bc189dcd1ae1613ac8de4ed393928d7d6790aL68-R68) [[3]](diffhunk://#diff-bfe606005f7adfb6b9a193d1e83bc189dcd1ae1613ac8de4ed393928d7d6790aL81-R85)