### PR TITLE
fix: 🐛 subscription history in descending order

### DIFF
--- a/includes/Admin/Subscriptions.php
+++ b/includes/Admin/Subscriptions.php
@@ -129,7 +129,7 @@ class Subscriptions {
 	public function add_custom_columns_data( $column, $post_id ) {
 		// HPOS: Safe. Only retrieves WooCommerce order via CRUD, and subscription meta via post meta.
 		$order_id = get_post_meta( $post_id, '_subscrpt_order_id', true ); // HPOS: Only subscription meta, not order meta.
-		$order = wc_get_order( $order_id ); // HPOS: Safe, uses WooCommerce CRUD.
+		$order    = wc_get_order( $order_id ); // HPOS: Safe, uses WooCommerce CRUD.
 		if ( $order ) {
 			if ( 'subscrpt_start_date' === $column ) {
 				$start_date = get_post_meta( $post_id, '_subscrpt_start_date', true );
@@ -222,11 +222,15 @@ class Subscriptions {
 		$subscription_id = $post->ID;
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'subscrpt_order_relation';
-        // @phpcs:ignore
-        $order_histories = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE subscription_id=%d', array(
-			$table_name,
-			$subscription_id,
-			)
+
+		// @phpcs:ignore
+		$order_histories = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE subscription_id=%d ORDER BY id DESC',
+				array(
+					$table_name,
+					$subscription_id,
+				)
 			)
 		);
 
@@ -497,7 +501,7 @@ class Subscriptions {
 
 	public function add_overview_submenu() {
 		// Remove and re-add submenu to ensure Overview is first
-		remove_submenu_page('edit.php?post_type=subscrpt_order', 'edit.php?post_type=subscrpt_order');
+		remove_submenu_page( 'edit.php?post_type=subscrpt_order', 'edit.php?post_type=subscrpt_order' );
 		add_submenu_page(
 			'edit.php?post_type=subscrpt_order',
 			__( 'Overview', 'wp_subscription' ),
@@ -516,7 +520,7 @@ class Subscriptions {
 			'',
 			1
 		);
-		if ( ! class_exists('Sdevs_Wc_Subscription_Pro') ) {
+		if ( ! class_exists( 'Sdevs_Wc_Subscription_Pro' ) ) {
 			add_submenu_page(
 				'edit.php?post_type=subscrpt_order',
 				__( 'Go Pro', 'wp_subscription' ),
@@ -606,7 +610,7 @@ class Subscriptions {
 	}
 
 	public function render_go_pro_page() {
-		if ( class_exists('Sdevs_Wc_Subscription_Pro') ) {
+		if ( class_exists( 'Sdevs_Wc_Subscription_Pro' ) ) {
 			echo '<div class="notice notice-info" style="margin:40px auto;max-width:700px;text-align:center;font-size:1.2em;">Pro is already active.</div>';
 			return;
 		}

--- a/includes/Admin/views/order-history.php
+++ b/includes/Admin/views/order-history.php
@@ -16,9 +16,8 @@ STYLE GUIDE FOR WP SUBSCRIPTION ADMIN PAGES:
 <table class="wp-list-table widefat fixed striped wp-subscription-modern-table" style="border-radius:6px;overflow:hidden;box-shadow:0 2px 8px #e0e7ef;">
 	<thead>
 		<tr>
-			<th style="width: 100px;"><?php
-			esc_html_e( 'ID', 'wp_subscription' ); ?></th>
-			<th></th>
+			<th style="width: 80px;"><?php esc_html_e( 'ID', 'wp_subscription' ); ?></th>
+			<th><?php esc_html_e( 'Order Type', 'wp_subscription' ); ?></th>
 			<th><?php esc_html_e( 'Date', 'wp_subscription' ); ?></th>
 			<th><?php esc_html_e( 'Status', 'wp_subscription' ); ?></th>
 			<th><?php esc_html_e( 'Amount', 'wp_subscription' ); ?></th>
@@ -28,35 +27,37 @@ STYLE GUIDE FOR WP SUBSCRIPTION ADMIN PAGES:
 	<tbody>
 		<?php foreach ( $order_histories as $order_history ) : ?>
 			<?php
-			$order      = wc_get_order( $order_history->order_id );
-			$order_item = $order->get_item( $order_history->order_item_id );
+				$order      = wc_get_order( $order_history->order_id );
+				$order_item = $order->get_item( $order_history->order_item_id );
 			?>
 			<tr>
-				<td><a href="<?php echo wp_kses_post( $order->get_edit_order_url() ); ?>" target="_blank"><?php echo wp_kses_post( $order_history->order_id ); ?></a></td>
-									<td><?php echo wp_kses_post( wps_subscription_order_relation_type_cast( $order_history->type ) ); ?></td>
+				<td>
+					<a href="<?php echo wp_kses_post( $order->get_edit_order_url() ); ?>" target="_blank">
+						<?php echo wp_kses_post( $order_history->order_id ); ?>
+					</a>
+				</td>
+				<td>
+					<?php echo wp_kses_post( wps_subscription_order_relation_type_cast( $order_history->type ) ); ?>
+				</td>
 				<td>
 					<?php
 					if ( $order ) {
-						echo wp_kses_post( gmdate( 'F d, Y', strtotime( $order->get_date_created() ) ) );}
+						echo wp_kses_post( gmdate( 'F d, Y', strtotime( $order->get_date_created() ) ) );
+					}
 					?>
 				</td>
 				<td>
-				<?php
-				if ( $order ) {
-					echo esc_html( sdevs_order_status_label( $order->get_status() ) );
-				}
-				?>
+					<?php
+					if ( $order ) {
+						echo esc_html( sdevs_order_status_label( $order->get_status() ) );
+					}
+					?>
 				</td>
 				<td>
-				<?php
-				echo wc_price(
-					$order_item->get_total(),
-					array(
-						'currency' => $order->get_currency(),
-					)
-				);
-				?>
-			</td>
+					<?php
+					echo wc_price( $order_item->get_total(), array( 'currency' => $order->get_currency() ) );
+					?>
+				</td>
 			</tr>
 		<?php endforeach; ?>
 	</tbody>


### PR DESCRIPTION
This pull request introduces improvements to the subscription order history functionality, focusing on query optimization, UI updates, and code readability. The most notable changes include adding an ordering clause to the database query, enhancing the order history table layout, and improving code formatting for better maintainability.

### Query Optimization:
* Updated the `order_histories` function in `includes/Admin/Subscriptions.php` to include an `ORDER BY id DESC` clause in the SQL query, ensuring the order history is displayed in descending order.

### UI Enhancements:
* Modified the order history table in `includes/Admin/views/order-history.php` by adding a new "Order Type" column.

### Code Readability:
* Refactored HTML and PHP code in `includes/Admin/views/order-history.php` to improve readability by breaking long lines into multiple lines and ensuring consistent formatting. [[1]](diffhunk://#diff-e5020113b7c43fe835e7cf4601e7ff73a4fb0b772fb86978bc8a0ae4cb6bdb27L35-R46) [[2]](diffhunk://#diff-e5020113b7c43fe835e7cf4601e7ff73a4fb0b772fb86978bc8a0ae4cb6bdb27L52-R58)