### PR TITLE
fix: 🐛 PayPal data conflict with live and sandbox

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -76,7 +76,7 @@
             }
         },
         "compatibility": {
-            "php": ">=7.0",
+            "php": ">=7.4",
             "wordpress": ">=4.6",
             "woocommerce": ">=3.0"
         },

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ WP Subscription aims to be the go-to subscription management solution for WordPr
 
 ### Prerequisites
 
-- PHP >= 7.0
+- PHP >= 7.4
 - WordPress >= 4.6
 - WooCommerce >= 3.0
 - Node.js (for frontend development)

--- a/includes/Admin/Subscriptions.php
+++ b/includes/Admin/Subscriptions.php
@@ -562,9 +562,9 @@ class Subscriptions {
 					</table>
 				</div>
 				
-				<!-- Important Dates -->
+				<!-- Schedule Dates -->
 				<div class="details-group">
-					<h3><?php esc_html_e( 'Important Dates', 'wp_subscription' ); ?></h3>
+					<h3><?php esc_html_e( 'Schedule Dates', 'wp_subscription' ); ?></h3>
 					<table>
 						<tr>
 							<th><?php esc_html_e( 'Started', 'wp_subscription' ); ?></th>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscription",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "author": "The WordPress Contributors",
   "license": "GPL-2.0-or-later",
   "main": "build/index.js",

--- a/readme.txt
+++ b/readme.txt
@@ -228,6 +228,9 @@ Learn more: [WPSubscription](https://wpsubscription.co/)
 
 == Changelog ==
 
+= 1.5.7 - Aug 24, 2025 =
+* fix: PayPal data conflict for Live and SandBox modes.
+
 = 1.5.6 - Aug 18, 2025 =
 * fix: 🐛 PayPal update order by webhook
 * fix: 🐛 Some subscription query dependency

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: converswp, shamsbd71
 Tags: woocommerce-subscriptions, subscriptions, subscriptions-billing, recurring-payments, woocommerce-extensions
 Requires at least: 6.0
 Tested up to: 6.8
-Stable tag: 1.5.6
+Stable tag: 1.5.7
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/subscription.php
+++ b/subscription.php
@@ -9,7 +9,7 @@
  * Text Domain: wp_subscription
  * Domain Path: /languages
  * Requires at least: 6.0
- * Requires PHP: 7.0
+ * Requires PHP: 7.4
  * WC requires at least: 6.0
  * WC tested up to: 9.9
  *

--- a/subscription.php
+++ b/subscription.php
@@ -3,7 +3,7 @@
  * Plugin Name: WPSubscription - Subscription & Recurring Payment Plugin for WooCommerce
  * Plugin URI: https://wpsubscription.co/
  * Description: WPSubscription allow WooCommerce to enables recurring payments, subscriptions, and auto-renewals for digital and physical products. Supports Stripe, PayPal, Paddle, and more.
- * Version: 1.5.6
+ * Version: 1.5.7
  * Author: ConversWP
  * Author URI: https://wpsubscription.co/
  * Text Domain: wp_subscription
@@ -40,7 +40,7 @@ final class Sdevs_Subscription {
 	 *
 	 * @var string
 	 */
-	const version = '1.5.6';
+	const version = '1.5.7';
 
 	/**
 	 * Holds various class instances


### PR DESCRIPTION
## Changes
Fixed PayPal Product ID, Subscription ID conflict for Live and Sandbox mode. Also added On-Demand meta key override. Added Backward compatibility for existing users.


## Summary
This pull request updates the PayPal gateway integration by introducing a migration path for an old subscription meta key and enhancing the meta key generation to be mode-aware (sandbox/live). These changes improve backward compatibility and data consistency across different environments.

**Meta key migration and backward compatibility:**

* Added logic to check for and migrate the old PayPal subscription meta key (`_wp_subs_paypal_subscription_id`) to the new key if the new key is missing, ensuring existing subscriptions continue to work after updates. [[1]](diffhunk://#diff-2e4cfdefd6e9f39fa4b948cd4ebfdbbf4898a52ddcb637375f4e00007228e888R349-R361) [[2]](diffhunk://#diff-2e4cfdefd6e9f39fa4b948cd4ebfdbbf4898a52ddcb637375f4e00007228e888R993-R1004)

**Meta key generation improvements:**

* Updated the `get_meta_key` method to include a mode prefix (`sandbox_` or `live_`) based on the current or overridden mode, reducing risk of conflicts and improving clarity between environments.