### PR TITLE
fix: 🐛 do not show cancel subs text on split payments

### DIFF
--- a/includes/Frontend/Cart.php
+++ b/includes/Frontend/Cart.php
@@ -473,7 +473,7 @@ class Cart {
 						?>
 							<?php echo esc_html( $billing_text ); ?>:
 							<?php echo esc_html( $recurr['trial_status'] ? $recurr['start_date'] : $recurr['next_date'] ); ?></small>
-						<?php if ( 'yes' === $recurr['can_user_cancel'] ) : ?>
+						<?php if ( 'yes' === $recurr['can_user_cancel'] && 0 !== (int) $recurr['max_no_payment'] ) : ?>
 							<br>
 							<small><?php esc_html_e( 'You can cancel subscription at any time!', 'subscription' ); ?></small>
 						<?php endif; ?>
@@ -481,7 +481,12 @@ class Cart {
 						<!-- add how many times will be build if _subscrpt_renewal_limit is not 0 -->
 						<?php if ( $recurr['max_no_payment'] > 0 ) : ?>
 							<br>
-							<small><?php esc_html_e( 'This subscription will be billed for', 'subscription' ); ?> <?php echo esc_html( $recurr['max_no_payment'] ); ?> <?php esc_html_e( 'times.', 'subscription' ); ?></small>
+							<small>
+								<?php
+								// translators: %s: number of payments.
+								echo esc_html( sprintf( __( 'This subscription will be billed for %s times.', 'subscription' ), esc_html( $recurr['max_no_payment'] ) ) );
+								?>
+							</small>
 						<?php endif; ?>
 					</p>
 				<?php endforeach; ?>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { ExperimentalOrderMeta, registerCheckoutFilters, TotalsItem } from "@woocommerce/blocks-checkout";
 import { FormattedMonetaryAmount } from "@woocommerce/blocks-components";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import { registerPlugin } from "@wordpress/plugins";
 
 import { getCurrencyFromPriceResponse } from "@woocommerce/price-format";
@@ -87,7 +87,7 @@ const RecurringTotals = ({ cart, extensions }) => {
                     : capitalizedType}
                 </div>
                 <small>{recurring.description}</small>
-                {recurring.can_user_cancel === "yes" && (
+                {recurring.can_user_cancel === "yes" && parseInt(recurring.max_no_payment) === 0 && (
                   <>
                     <br />
                     <small>{__("You can cancel subscription at any time!", "subscription")} </small>
@@ -97,8 +97,13 @@ const RecurringTotals = ({ cart, extensions }) => {
                   <>
                     <br />
                     <small>
-                      {__("This subscription will be billed for", "subscription")} {recurring.max_no_payment}{" "}
-                      {__("times.", "subscription")}
+                      {
+                        // translators: %s: number of payments.
+                        sprintf(
+                          __("This subscription will be billed for %s times.", "subscription"),
+                          recurring.max_no_payment,
+                        )
+                      }
                     </small>
                   </>
                 )}


### PR DESCRIPTION
Do not show "You can cancel subscription at any time!" text if it is a split payment.