### PR TITLE
fix: 🐛 abstract method

### DIFF
--- a/includes/Utils/Product.php
+++ b/includes/Utils/Product.php
@@ -134,7 +134,7 @@ abstract class Product {
 		return $this->product->get_meta( '_subscrpt_trial_timing_option' );
 	}
 
-	public function get_signup_fee(): int {
+	public function get_signup_fee(): float {
 		return 0;
 	}
 


### PR DESCRIPTION
Fixed the return type of the `get_signup_fee` method!