### PR TITLE
Fix: Prevent setup_future_usage from being added to renewal orders

### DIFF
--- a/includes/Illuminate/Gateways/Stripe/Stripe.php
+++ b/includes/Illuminate/Gateways/Stripe/Stripe.php
@@ -401,7 +401,10 @@ class Stripe extends \WC_Stripe_Payment_Gateway {
 	 */
 	public function modify_create_intent_request_for_subscriptions( $request, $order, $prepared_source ) {
 		$is_subscription_order = $this->order_has_subscription_relation( $order->get_id() );
-		if ( ! $is_subscription_order ) {
+		$is_renewal_order      = $this->is_subscription_renewal_order( $order->get_id() );
+
+		// Don't add setup_future_usage for renewal orders (payment method already saved)
+		if ( ! $is_subscription_order || $is_renewal_order ) {
 			return $request;
 		}
 


### PR DESCRIPTION
Adds renewal order check in modify_create_intent_request_for_subscriptions() to prevent setup_future_usage from being added for renewal payments.

When setup_future_usage is present on renewal orders, Stripe requests 3D Secure authentication even though the payment method is already saved from the initial subscription purchase. Since customers are not present during automatic renewals, this causes payments to fail with "3D Secure authentication incomplete" error.

The fix:
- Checks is_subscription_renewal_order() before adding setup_future_usage
- Only adds setup_future_usage for NEW subscription orders
- Renewals use the already-saved payment method with off_session: true

This resolves renewal failures for Stripe Link and card payments with 3DS.