### PR TITLE
Hotfix/org guideline volation mar 15 26

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,204 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Install Dependencies
+
+```bash
+yarn install-dev   # installs both npm and composer deps
+# or separately:
+yarn install --ignore-engines
+composer install --ignore-platform-req=php
+```
+
+### JavaScript Build
+
+```bash
+yarn build          # build JS (wp-scripts) + Tailwind CSS
+yarn watch          # watch mode for both
+yarn build:wpscripts
+yarn watch:wpscripts
+yarn build:tailwind
+yarn watch:tailwind
+```
+
+### PHP Linting / Formatting
+
+```bash
+yarn lint:php       # runs phpcs
+yarn format:php     # runs phpcbf (auto-fix)
+```
+
+### JS Linting / Formatting
+
+```bash
+yarn format         # wp-scripts format
+yarn format:prettier
+```
+
+## Architecture
+
+### Plugin Bootstrap
+
+`subscription.php` defines the `Sdevs_Subscription` singleton (kept as-is for backwards compatibility with Pro). On `plugins_loaded` it calls `init_plugin()`, which loads three loader classes based on request context: `Admin`, `Frontend`, and `Illuminate`. The `init` hook then loads `Ajax`, `API`, and `Assets`.
+
+`define_constants()` runs first and also requires `includes/LegacyCompat.php`, which provides backwards-compatible aliases for old constant and function names.
+
+### Three-Layer Structure
+
+- **`includes/Admin/`** — Settings pages, product configuration UI, subscription list/management, admin order details.
+- **`includes/Frontend/`** — Product display, cart, checkout (including guest auto-login for new accounts only), My Account pages, action controller (pause/resume/cancel).
+- **`includes/Illuminate/`** — Core business logic: subscription post type, cron jobs, email dispatch, auto-renewal, guest checkout, WooCommerce Blocks integration, payment gateways (`Gateways/Stripe/`, `Gateways/Paypal/`).
+
+### Namespace & Autoloading
+
+Namespace root: `SpringDevs\Subscription\` → PSR-4 mapped to `includes/`.
+The main plugin file and its singleton (`Sdevs_Subscription`) are not namespaced — do not change these names; Pro depends on `class_exists('Sdevs_Subscription')` as a load guard.
+
+### Constants
+
+All plugin constants use the `SUBSCRPT_` prefix since v1.9.2:
+
+| Constant             | Value                               |
+| -------------------- | ----------------------------------- |
+| `SUBSCRPT_VERSION`   | Plugin version string               |
+| `SUBSCRPT_FILE`      | Absolute path to `subscription.php` |
+| `SUBSCRPT_PATH`      | Plugin root directory               |
+| `SUBSCRPT_INCLUDES`  | `SUBSCRPT_PATH/includes`            |
+| `SUBSCRPT_TEMPLATES` | `SUBSCRPT_PATH/templates/`          |
+| `SUBSCRPT_URL`       | Plugin root URL                     |
+| `SUBSCRPT_ASSETS`    | `SUBSCRPT_URL/assets`               |
+
+The old `WP_SUBSCRIPTION_*` names are still defined via `includes/LegacyCompat.php` for backwards compatibility but are deprecated. Always use `SUBSCRPT_*` in new code.
+
+### Templates
+
+- **`templates/myaccount/`** — Customer-facing subscription list and detail views.
+- **`templates/emails/`** — Transactional email templates.
+- **`includes/Admin/views/`** — Admin UI views (settings, product form, subscription list).
+
+### Assets / JavaScript
+
+- **`src/`** → built to **`build/`** via `@wordpress/scripts` (Webpack). `webpack.config.js` uses WooCommerce dependency extraction alongside the WordPress default.
+- **Tailwind CSS** is scoped under the class `wpsubs-tw-root` to avoid global style leaks. Input: `assets/css/tailwind/input.css`, output: `assets/css/tailwind/output.css`. Tailwind scans `src/**`, `templates/**`, and `includes/**`.
+
+### REST API
+
+`includes/API.php` registers on `rest_api_init` and is the intended home for all future REST endpoints. It is currently a stub. New REST routes should be added here.
+
+### WooCommerce Integration Points
+
+- Custom `subscrpt_order` post type registered in `Illuminate/Post.php`.
+- Payment gateways inside `Illuminate/Gateways/` extend WooCommerce gateway base classes. The Stripe class is wrapped in `class_exists('\WC_Stripe_Payment_Gateway')` — always guard gateway classes this way.
+- Blocks (Cart/Checkout) integrated via `Illuminate/Block.php` and `Illuminate/Gateways/Paypal/Paypal_Blocks_Integration.php`.
+- HPOS compatibility declared in `subscription.php`.
+
+### Cron & Auto-Renewal
+
+`Illuminate/Cron.php` schedules WordPress cron events for renewal reminders and expiration checks. `Illuminate/AutoRenewal.php` handles payment retry logic and fires grace-period hooks.
+
+---
+
+## Pro Plugin Integration
+
+The Pro plugin (`subscription-pro/`) is a separate plugin that extends this one entirely through WordPress hooks. It **never** modifies free plugin files.
+
+### Load guard
+
+Pro checks `class_exists('Sdevs_Subscription')` before initialising. Do not rename that class.
+
+### How Pro extends Free
+
+Pro registers listeners on `subscrpt_*` hooks fired by the free plugin. Never remove or rename a `subscrpt_` hook without a deprecation plan — Pro and third-party integrations depend on them.
+
+### Key hooks Pro listens to
+
+**Subscription lifecycle (from `Illuminate/Action.php`)**
+| Hook | Fired when |
+|---|---|
+| `subscrpt_subscription_activated` | Subscription becomes active |
+| `subscrpt_subscription_cancelled` | Subscription cancelled |
+| `subscrpt_subscription_expired` | Subscription expired |
+| `subscrpt_subscription_pending` | Subscription set to pending |
+| `subscrpt_subscription_resumed` | Subscription resumed from pause |
+| `subscrpt_subscription_pending_cancellation` | Cancellation scheduled |
+| `subscrpt_subscription_status_changed` | Any status transition `($id, $old, $new)` |
+
+**Checkout & orders**
+| Hook | Fired when |
+|---|---|
+| `subscrpt_product_checkout` | New subscription created at checkout `($order_item, $product, $status)` |
+| `subscrpt_order_checkout` | Order linked to subscription `($subscription_id, $order_item)` |
+| `subscrpt_after_create_renew_order` | Renewal order created `($new_order, $old_order, $subscription_id)` |
+| `subscrpt_before_saving_renewal_order` | Filter — modify renewal order before save |
+
+**Cron / grace period**
+| Hook | Fired when |
+|---|---|
+| `subscrpt_grace_period_started` | Grace period begins |
+| `subscrpt_grace_period_ended` | Grace period ends |
+| `subscrpt_split_payment_completed` | All split-payment instalments received |
+
+**Admin UI extension points**
+| Hook | Purpose |
+|---|---|
+| `subscrpt_simple_pro_fields` | Inject extra fields into the product settings panel |
+| `subscrpt_settings_fields` | Filter to add settings fields |
+| `subscrpt_admin_info_rows` | Filter subscription detail rows in admin |
+| `subscrpt_order_activities` | Action to append activity log entries |
+| `subscrpt_render_stats_page` | Action to render the Reports page content (Pro replaces the upsell) |
+| `wp_subscription_render_stats_page` | Legacy alias of the above — kept alive for Pro compatibility |
+
+**Frontend extension points**
+| Hook | Purpose |
+|---|---|
+| `subscrpt_single_action_buttons` | Filter action buttons on My Account subscription page |
+| `subscrpt_execute_actions` | Action to handle custom subscription actions |
+| `subscrpt_after_subscription_totals` | Action to append content after subscription totals |
+| `subscrpt_simple_price_html` | Filter subscription price HTML on product page |
+| `subscrpt_block_simple_cart_item_data` | Filter cart item data for block cart |
+| `subscrpt_admin_header_menu_items` | Filter admin header nav items |
+
+---
+
+## Code Standards
+
+### Naming — enforced prefix: `subscrpt_` / `SUBSCRPT_`
+
+All new global PHP symbols must use `subscrpt_` (functions, hooks, post types, options) or `SUBSCRPT_` (constants). The `.cursorrules` file lists `WPS_`/`wps_` — that is outdated; ignore it. Class names inside the `SpringDevs\Subscription\` namespace do not need the prefix.
+
+### CSS class naming
+
+- **Legacy (existing):** `wp-subscription-` prefix — do not rename existing classes; templates depend on them.
+- **New components:** use `subscrpt-` prefix going forward.
+- **Next UI pass:** admin UI will migrate to WordPress core UI components (buttons, cards, notices from `@wordpress/components`). Do not add new custom-styled admin UI components that duplicate WP core patterns.
+
+### Admin UI conventions (current, until next UI pass)
+
+From the in-file style guide in `includes/Admin/views/required-notice.php`:
+
+- Main content wrapper: `wp-subscription-admin-content`
+- White card/box: `wp-subscription-admin-box` (white, box-shadow, 6–8 px border-radius)
+- Header: `wp-subscription-admin-header` (sticky, `top: 32px`)
+- Title font: Georgia, serif. Body: system sans-serif.
+- Tailwind utilities are available inside any element with class `wpsubs-tw-root`.
+
+### PHP Rules (enforced by PHPCS / `phpcs.xml`)
+
+- WordPress Coding Standards, PHP 7.4+ target, minimum WP 5.0.
+- Excluded rules: file naming, `PrefixAllGlobals`, Yoda conditions, short array syntax.
+- All output must be escaped (`esc_html`, `esc_attr`, `wp_kses_post`). All input sanitized. AJAX handlers must verify nonces and `current_user_can()`.
+- Use `wp_safe_redirect()` + `exit` for redirects — never `echo "<script>location.href=..."`.
+- Gateway classes that extend external base classes (Stripe, etc.) must be wrapped in `class_exists()`.
+
+### Documentation
+
+PHPDoc on all classes, methods, global functions, `do_action`, and `apply_filters` calls. JSDoc on JS functions.
+
+## Compatibility Requirements
+
+- PHP >= 7.4
+- WordPress >= 6.0
+- WooCommerce >= 6.0

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -131,7 +131,7 @@ jQuery(document).ready(() => {
       url: wp_subscription_ajax.ajaxurl,
       type: "POST",
       data: {
-        action: "wp_subscription_bulk_action",
+        action: "subscrpt_bulk_action",
         bulk_action: action,
         subscription_ids: subscriptionIds,
         nonce: wp_subscription_ajax.nonce,

--- a/assets/js/installer.js
+++ b/assets/js/installer.js
@@ -15,7 +15,7 @@ jQuery(document).ready(function ($) {
       url: sdevs_installer_helper_obj.ajax_url,
       data: {
         install_plugin: "woocommerce",
-        action: "install_woocommerce_plugin",
+        action: "subscrpt_install_woocommerce_plugin",
       },
       beforeSend: function () {
         $(".sdevs-loading-icon").show();
@@ -35,7 +35,7 @@ jQuery(document).ready(function ($) {
       url: sdevs_installer_helper_obj.ajax_url,
       data: {
         activate_plugin: "woocommerce",
-        action: "wps_subscription_activate_woocommerce_plugin",
+        action: "subscrpt_activate_woocommerce_plugin",
       },
       beforeSend: function () {
         $(".sdevs-loading-icon").show();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,17 @@
 *** WPSubscription Changelog ***
 
+2026-03-29 - version 1.9.2
+* fix: Renamed reserved WP_SUBSCRIPTION_* constants to SUBSCRPT_* to comply with WordPress.org naming guidelines.
+* fix: Renamed wp_-prefixed global functions (wp_subscrpt_write_log, wp_subs_multiselect_field, etc.) to subscrpt_ prefix.
+* fix: Renamed non-prefixed AJAX actions (install_woocommerce_plugin, activate_woocommerce_plugin) to subscrpt_ prefix.
+* fix: Stripe gateway class now wrapped in class_exists check to prevent fatal error when WooCommerce Stripe plugin is inactive.
+* fix: Guest checkout auto-login now restricted to newly created accounts only, preventing unexpected re-login for existing users.
+* fix: Replaced insecure JavaScript location.href redirects in ActionController with wp_safe_redirect().
+* fix: PayPal webhook inputs now sanitized before processing.
+* fix: Settings field output now escaped with wp_kses_post for improved security.
+* fix: Plugin name updated to comply with WordPress.org trademark guidelines.
+* compat: Legacy WP_SUBSCRIPTION_* constants and old function names remain available via includes/LegacyCompat.php.
+
 2026-03-15 - version 1.9.1
 * fix: Subscription trials.
 * fix: Cart text issue.

--- a/docs/release-1.9.2-developer-notes.md
+++ b/docs/release-1.9.2-developer-notes.md
@@ -1,0 +1,153 @@
+# WP Subscription 1.9.2 — Developer Notes
+
+**Release date:** 2026-03-29
+
+This release is a compliance and security update driven by a WordPress.org plugin directory review. No features were added or removed. If you only use WP Subscription as a store owner you do not need to do anything — all changes are backwards-compatible. If you extend the plugin via code (custom code, a child plugin, or integrations), read the sections below.
+
+---
+
+## Why these changes were made
+
+WordPress.org requires that every plugin use a unique prefix for all global PHP symbols (constants, functions, AJAX actions). Using reserved prefixes like `wp_` or generic names like `install_woocommerce_plugin` risks conflicts with WordPress core and other plugins. The reviewer flagged 30+ declarations in WP Subscription using the `WP_SUBSCRIPTION_`, `wp_subscrpt_`, and `wp_subs_` prefixes. This release resolves all of them.
+
+---
+
+## What changed
+
+### 1. Plugin constants renamed
+
+All plugin-level PHP constants have been renamed to use the `SUBSCRPT_` prefix.
+
+| Old name (deprecated)       | New name             |
+| --------------------------- | -------------------- |
+| `WP_SUBSCRIPTION_VERSION`   | `SUBSCRPT_VERSION`   |
+| `WP_SUBSCRIPTION_FILE`      | `SUBSCRPT_FILE`      |
+| `WP_SUBSCRIPTION_PATH`      | `SUBSCRPT_PATH`      |
+| `WP_SUBSCRIPTION_INCLUDES`  | `SUBSCRPT_INCLUDES`  |
+| `WP_SUBSCRIPTION_TEMPLATES` | `SUBSCRPT_TEMPLATES` |
+| `WP_SUBSCRIPTION_URL`       | `SUBSCRPT_URL`       |
+| `WP_SUBSCRIPTION_ASSETS`    | `SUBSCRPT_ASSETS`    |
+
+**The old names still work.** They are defined as aliases in `includes/LegacyCompat.php` immediately after the new constants are set, so existing code referencing `WP_SUBSCRIPTION_PATH` etc. will continue to work without modification. The aliases will be removed in a future major release.
+
+### 2. Global functions renamed
+
+Three global functions had a reserved `wp_` prefix and have been renamed:
+
+| Old name (deprecated)           | New name                       |
+| ------------------------------- | ------------------------------ |
+| `wp_subscrpt_write_log()`       | `subscrpt_write_log()`         |
+| `wp_subscrpt_write_debug_log()` | `subscrpt_write_debug_log()`   |
+| `wp_subs_multiselect_field()`   | `subscrpt_multiselect_field()` |
+
+One top-level function previously declared at global scope was renamed:
+
+| Old name (deprecated)                     | New name                           |
+| ----------------------------------------- | ---------------------------------- |
+| `wp_subscription_register_paypal_block()` | `subscrpt_register_paypal_block()` |
+
+**The old names still work** via wrapper functions in `includes/LegacyCompat.php`. They will be removed in a future major release.
+
+### 3. AJAX actions renamed
+
+Two AJAX actions had no plugin prefix, making them prone to conflicts:
+
+| Old action (deprecated)               | New action                                     |
+| ------------------------------------- | ---------------------------------------------- |
+| `wp_ajax_install_woocommerce_plugin`  | `wp_ajax_subscrpt_install_woocommerce_plugin`  |
+| `wp_ajax_activate_woocommerce_plugin` | `wp_ajax_subscrpt_activate_woocommerce_plugin` |
+
+If you have custom JavaScript that calls either of these actions directly via `$.ajax({ action: '...' })`, update the action string. The old action names are **not** aliased — they were non-prefixed and therefore could not be safely kept active.
+
+### 4. Stripe class guarded with `class_exists`
+
+The `Stripe` gateway class (`includes/Illuminate/Gateways/Stripe/Stripe.php`) extends `\WC_Stripe_Payment_Gateway`, which is provided by the separate WooCommerce Stripe plugin. Previously the class declaration was unconditional, causing a PHP fatal error if WooCommerce Stripe was not installed. The class is now declared inside a `class_exists( '\WC_Stripe_Payment_Gateway' )` guard.
+
+No API change — the class name and namespace are unchanged.
+
+### 5. Guest checkout auto-login scoped to new accounts only
+
+**Class:** `SpringDevs\Subscription\Frontend\Checkout`
+**Method:** `handle_guest_checkout()` (internal)
+
+Previously, the auto-login at checkout fired for any guest completing a subscription order — including existing users who were not logged in. This could silently log an existing customer back in, overriding their session choice. The auto-login now fires **only when a brand-new WordPress account is created** during checkout.
+
+If you hooked into `wp_login` or `set_auth_cookie` to detect subscription checkouts, be aware it will no longer fire for returning customers going through guest checkout.
+
+### 6. Redirects changed from JavaScript to `wp_safe_redirect()`
+
+**Class:** `SpringDevs\Subscription\Frontend\ActionController`
+**Methods:** `handle_action()`, `redirect()`
+
+All subscription action redirects (renew, pause, cancel, etc.) previously used inline `<script>location.href='...'</script>` output. These have been replaced with `wp_safe_redirect()` + `exit`. The behaviour is identical from the user's perspective.
+
+If you call `ActionController::redirect()` directly and expected HTML output, it now exits immediately after the redirect header. Make sure you are not buffering or processing its return value.
+
+### 7. Security hardening (no API changes)
+
+- **PayPal webhook handler:** `event_type`, `sale_id`, `billing_agreement_id`, and related fields from the webhook payload are now passed through `sanitize_text_field()` before use.
+- **Settings field rendering:** `SettingsHelper` output methods now pass HTML through `wp_kses_post()` instead of printing raw.
+- **Plugin name:** Renamed from "Subscription & Recurring Payment **Plugin** for WooCommerce" to "Subscription & Recurring Payment for WooCommerce" to comply with WordPress.org trademark guidelines (the word "Plugin" in the name is disallowed).
+
+---
+
+## Migration guide
+
+### If you use the constants
+
+No action needed now. To future-proof your code, do a find-and-replace:
+
+```
+WP_SUBSCRIPTION_VERSION   → SUBSCRPT_VERSION
+WP_SUBSCRIPTION_FILE      → SUBSCRPT_FILE
+WP_SUBSCRIPTION_PATH      → SUBSCRPT_PATH
+WP_SUBSCRIPTION_INCLUDES  → SUBSCRPT_INCLUDES
+WP_SUBSCRIPTION_TEMPLATES → SUBSCRPT_TEMPLATES
+WP_SUBSCRIPTION_URL       → SUBSCRPT_URL
+WP_SUBSCRIPTION_ASSETS    → SUBSCRPT_ASSETS
+```
+
+### If you call the renamed functions
+
+No action needed now. To future-proof:
+
+```
+wp_subscrpt_write_log()       → subscrpt_write_log()
+wp_subscrpt_write_debug_log() → subscrpt_write_debug_log()
+wp_subs_multiselect_field()   → subscrpt_multiselect_field()
+```
+
+### If you call the AJAX actions from JavaScript
+
+**Action required.** Update your AJAX calls:
+
+```js
+// Before
+{
+  action: "install_woocommerce_plugin";
+}
+{
+  action: "wps_subscription_activate_woocommerce_plugin";
+}
+
+// After
+{
+  action: "subscrpt_install_woocommerce_plugin";
+}
+{
+  action: "subscrpt_activate_woocommerce_plugin";
+}
+```
+
+### If you extend `ActionController`
+
+If you override the `redirect()` method, update your override to use `wp_safe_redirect()` + `exit` instead of printing a `<script>` tag.
+
+---
+
+## Compatibility
+
+- WP Subscription Pro: fully compatible. No changes needed in the Pro plugin.
+- PHP: 7.4+
+- WordPress: 6.0+
+- WooCommerce: 6.0+

--- a/includes/Admin/Integrations.php
+++ b/includes/Admin/Integrations.php
@@ -31,7 +31,7 @@ class Integrations {
 		add_action( 'admin_menu', array( $this, 'register_admin_menu' ), 20 );
 
 		// WP Subscription navbar.
-		add_filter( 'wp_subscription_admin_header_menu_items', [ $this, 'add_integrations_menu_item' ], 10, 2 );
+		add_filter( 'subscrpt_admin_header_menu_items', [ $this, 'add_integrations_menu_item' ], 10, 2 );
 
 		// Enqueue integrations scripts.
 		// add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_integrations_scripts' ] );
@@ -86,7 +86,7 @@ class Integrations {
 	 * Enqueue scripts for integrations page.
 	 */
 	public function enqueue_integrations_scripts() {
-		wp_enqueue_script( 'wp-subs-integrations', WP_SUBSCRIPTION_ASSETS . '/js/integration_settings.js', [ 'jquery' ], WP_SUBSCRIPTION_VERSION, true );
+		wp_enqueue_script( 'wp-subs-integrations', SUBSCRPT_ASSETS . '/js/integration_settings.js', [ 'jquery' ], SUBSCRPT_VERSION, true );
 
 		wp_localize_script(
 			'wp-subs-integrations',
@@ -204,7 +204,7 @@ class Integrations {
 			[
 				'title'              => 'PayPal for WP Subscription',
 				'description'        => 'Accept subscription payments via PayPal.',
-				'icon_url'           => WP_SUBSCRIPTION_ASSETS . '/images/paypal.svg',
+				'icon_url'           => SUBSCRPT_ASSETS . '/images/paypal.svg',
 				'is_installed'       => 'on' === get_option( 'wp_subs_paypal_integration_enabled', 'off' ),
 				'is_active'          => self::is_gateway_enabled( 'wp_subscription_paypal' ),
 				'supports_recurring' => true,
@@ -255,7 +255,7 @@ class Integrations {
 			[
 				'title'              => 'Paddle',
 				'description'        => 'Process subscription payments securely with Paddle.',
-				'icon_url'           => WP_SUBSCRIPTION_ASSETS . '/images/paddle.svg',
+				'icon_url'           => SUBSCRPT_ASSETS . '/images/paddle.svg',
 				'is_installed'       => class_exists( 'SmartPayWoo\Gateways\Paddle\SmartPay_Paddle' ),
 				'is_active'          => self::is_gateway_enabled( 'smartpay_paddle' ),
 				'supports_recurring' => true,
@@ -356,7 +356,7 @@ class Integrations {
 		$integrations = $this->filter_integration_actions( $integrations );
 
 		// Integrations styles.
-		// wp_enqueue_style( 'wp-subs-integration-settings', WP_SUBSCRIPTION_ASSETS . '/css/integration_settings.css', [], WP_SUBSCRIPTION_VERSION, 'all' );
+		// wp_enqueue_style( 'wp-subs-integration-settings', SUBSCRPT_ASSETS . '/css/integration_settings.css', [], SUBSCRPT_VERSION, 'all' );
 
 		$menu = new \SpringDevs\Subscription\Admin\Menu();
 		$menu->render_admin_header();

--- a/includes/Admin/Links.php
+++ b/includes/Admin/Links.php
@@ -28,7 +28,7 @@ class Links {
 			$links[] = '<a href="https://wpsubscription.co" target="_blank" style="color:#3db634;">' . __( 'Upgrade to premium', 'subscription' ) . '</a>';
 		}
 		$links[] = '<a href="https://wordpress.org/support/plugin/subscription" target="_blank">' . __( 'Support', 'subscription' ) . '</a>';
-		$links[] = '<a href="https://wordpress.org/support/plugin/subscription/reviews/?rate=5#new-post" target="_blank">' . __( 'Review', 'subscription' ) . '</a>';
+		$links[] = '<a href="https://wordpress.org/support/plugin/subscription/reviews/" target="_blank">' . __( 'Review', 'subscription' ) . '</a>';
 		return $links;
 	}
 }

--- a/includes/Admin/Links.php
+++ b/includes/Admin/Links.php
@@ -15,7 +15,7 @@ class Links {
 	 * Initialize the class
 	 */
 	public function __construct() {
-		add_filter( 'plugin_action_links_' . plugin_basename( WP_SUBSCRIPTION_FILE ), array( $this, 'plugin_action_links' ) );
+		add_filter( 'plugin_action_links_' . plugin_basename( SUBSCRPT_FILE ), array( $this, 'plugin_action_links' ) );
 	}
 
 	/**

--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -426,8 +426,6 @@ class Menu {
 		} else {
 			// Allow pro plugin to override the entire stats page content.
 			do_action( 'subscrpt_render_stats_page' );
-			// Legacy hook alias — subscription-pro hooks into this name.
-			do_action( 'wp_subscription_render_stats_page' );
 		}
 
 		$this->render_admin_footer();

--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -15,7 +15,7 @@ class Menu {
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'create_admin_menu' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
-		add_action( 'wp_ajax_wp_subscription_bulk_action', array( $this, 'handle_bulk_action_ajax' ) );
+		add_action( 'wp_ajax_subscrpt_bulk_action', array( $this, 'handle_bulk_action_ajax' ) );
 	}
 
 	/**
@@ -24,17 +24,17 @@ class Menu {
 	public function enqueue_admin_assets() {
 		wp_enqueue_style(
 			'wp-subscription-admin',
-			WP_SUBSCRIPTION_ASSETS . '/css/admin.css',
+			SUBSCRPT_ASSETS . '/css/admin.css',
 			array(),
-			WP_SUBSCRIPTION_VERSION
+			SUBSCRPT_VERSION
 		);
 
 		// Enqueue admin JavaScript for subscription list functionality
 		wp_enqueue_script(
 			'sdevs_subscription_admin',
-			WP_SUBSCRIPTION_ASSETS . '/js/admin.js',
+			SUBSCRPT_ASSETS . '/js/admin.js',
 			array( 'jquery' ),
-			WP_SUBSCRIPTION_VERSION,
+			SUBSCRPT_VERSION,
 			true
 		);
 
@@ -43,7 +43,7 @@ class Menu {
 			'sdevs_subscription_admin',
 			'wp_subscription_ajax',
 			array(
-				'nonce'   => wp_create_nonce( 'wp_subscription_bulk_action_nonce' ),
+				'nonce'   => wp_create_nonce( 'subscrpt_bulk_action_nonce' ),
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
 			)
 		);
@@ -57,8 +57,8 @@ class Menu {
 		// Determine if the menu is active
 		$is_active = isset( $_GET['page'] ) && strpos( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 'wp-subscription' ) === 0;
 		$icon_url  = $is_active
-			? WP_SUBSCRIPTION_ASSETS . '/images/icons/subscription-20.png'
-			: WP_SUBSCRIPTION_ASSETS . '/images/icons/subscription-20-gray.png';
+			? SUBSCRPT_ASSETS . '/images/icons/subscription-20.png'
+			: SUBSCRPT_ASSETS . '/images/icons/subscription-20-gray.png';
 		// Main menu
 		add_menu_page(
 			__( 'WP Subscription', 'subscription' ),
@@ -162,7 +162,7 @@ class Menu {
 			],
 		];
 		// Allow pro plugin to inject menu items
-		$menu_items = apply_filters( 'wp_subscription_admin_header_menu_items', $menu_items, $current );
+		$menu_items = apply_filters( 'subscrpt_admin_header_menu_items', $menu_items, $current );
 		$menu_items = array_merge(
 			$menu_items,
 			[
@@ -177,7 +177,7 @@ class Menu {
 		<div class="wp-subscription-admin-header">
 			<div style="width:1240px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;">
 				<div class="wp-subscription-admin-header-left" style="display:flex;align-items:center;gap:14px;">
-					<img style="height:30px;" src="<?php echo esc_url( WP_SUBSCRIPTION_ASSETS . '/images/logo-title.svg' ); ?>" alt="WP Subscription" class="wp-subscription-logo">
+					<img style="height:30px;" src="<?php echo esc_url( SUBSCRPT_ASSETS . '/images/logo-title.svg' ); ?>" alt="WP Subscription" class="wp-subscription-logo">
 					<nav class="wp-subscription-admin-header-menu">
 						<?php foreach ( $menu_items as $item ) : ?>
 							<a href="<?php echo esc_url( $item['url'] ); ?>" class="<?php echo ( $current === $item['slug'] ) ? 'current' : ''; ?>">
@@ -214,7 +214,7 @@ class Menu {
 		if ( 'POST' === $request_method ) {
 			// Verify nonce before processing any POST data.
 			$nonce = isset( $_POST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ) : '';
-			if ( ! wp_verify_nonce( $nonce, 'wp_subscription_list_action' ) ) {
+			if ( ! wp_verify_nonce( $nonce, 'subscrpt_list_action' ) ) {
 				wp_die( esc_html__( 'Security check failed.', 'subscription' ) );
 			}
 			// Handle bulk actions
@@ -424,7 +424,9 @@ class Menu {
 			</div>
 			<?php
 		} else {
-			// Allow pro plugin to override the entire stats page content
+			// Allow pro plugin to override the entire stats page content.
+			do_action( 'subscrpt_render_stats_page' );
+			// Legacy hook alias — subscription-pro hooks into this name.
 			do_action( 'wp_subscription_render_stats_page' );
 		}
 
@@ -571,7 +573,7 @@ class Menu {
 	public function handle_bulk_action_ajax() {
 		// Verify nonce
 		$nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
-		if ( ! wp_verify_nonce( $nonce, 'wp_subscription_bulk_action_nonce' ) ) {
+		if ( ! wp_verify_nonce( $nonce, 'subscrpt_bulk_action_nonce' ) ) {
 			wp_send_json_error( array( 'message' => __( 'Security check failed.', 'subscription' ) ) );
 		}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -242,9 +242,9 @@ class Settings {
 		// Only load on our settings page
 		if ( isset( $_GET['post_type'] ) && strpos( sanitize_text_field( wp_unslash( $_GET['post_type'] ) ), 'subscrpt_order' ) !== false ) {
 			// WooCommerce admin styles
-			wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WP_SUBSCRIPTION_VERSION );
+			wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), SUBSCRPT_VERSION );
 			// Optional: WooCommerce enhanced select2
-			wp_enqueue_style( 'woocommerce_admin_select2', WC()->plugin_url() . '/assets/css/select2.css', array(), WP_SUBSCRIPTION_VERSION );
+			wp_enqueue_style( 'woocommerce_admin_select2', WC()->plugin_url() . '/assets/css/select2.css', array(), SUBSCRPT_VERSION );
 			wp_enqueue_script( 'select2' );
 		}
 	}

--- a/includes/Admin/SettingsHelper.php
+++ b/includes/Admin/SettingsHelper.php
@@ -351,7 +351,10 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
+		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
+		// wp_kses_post cannot be used here as it strips <input>, <label> and other form elements.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return $should_print ? print( $html_content ) : $html_content;
 	}
 
 	/**
@@ -438,7 +441,10 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
+		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
+		// wp_kses_post cannot be used here as it strips <input>, <label> and other form elements.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return $should_print ? print( $html_content ) : $html_content;
 	}
 
 	/**
@@ -491,7 +497,10 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
+		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
+		// wp_kses_post cannot be used here as it strips <select>, <option> and other form elements.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return $should_print ? print( $html_content ) : $html_content;
 	}
 
 	/**
@@ -558,6 +567,9 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
+		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
+		// wp_kses_post cannot be used here as it strips <input>, <label> and other form elements.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return $should_print ? print( $html_content ) : $html_content;
 	}
 }

--- a/includes/Admin/SettingsHelper.php
+++ b/includes/Admin/SettingsHelper.php
@@ -297,9 +297,7 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		// Output not escaped intentionally. Breaks the HTML structure when escaped.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		return $should_print ? print( $html_content ) : $html_content;
+		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
 	}
 
 	/**
@@ -353,9 +351,7 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		// Output not escaped intentionally. Breaks the HTML structure when escaped.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		return $should_print ? print( $html_content ) : $html_content;
+		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
 	}
 
 	/**
@@ -442,9 +438,7 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		// Output not escaped intentionally. Breaks the HTML structure when escaped.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		return $should_print ? print( $html_content ) : $html_content;
+		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
 	}
 
 	/**
@@ -497,9 +491,7 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		// Output not escaped intentionally. Breaks the HTML structure when escaped.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		return $should_print ? print( $html_content ) : $html_content;
+		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
 	}
 
 	/**
@@ -566,8 +558,6 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		// Output not escaped intentionally. Breaks the HTML structure when escaped.
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		return $should_print ? print( $html_content ) : $html_content;
+		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
 	}
 }

--- a/includes/Admin/SettingsHelper.php
+++ b/includes/Admin/SettingsHelper.php
@@ -297,7 +297,9 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
-		return $should_print ? print( wp_kses_post( $html_content ) ) : $html_content;
+		// Output not escaped intentionally. Breaks the HTML structure when escaped.
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return $should_print ? print( $html_content ) : $html_content;
 	}
 
 	/**
@@ -351,9 +353,9 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
+		// Output not escaped intentionally. Breaks the HTML structure when escaped.
 		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
-		// wp_kses_post cannot be used here as it strips <input>, <label> and other form elements.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $should_print ? print( $html_content ) : $html_content;
 	}
 
@@ -441,9 +443,9 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
+		// Output not escaped intentionally. Breaks the HTML structure when escaped.
 		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
-		// wp_kses_post cannot be used here as it strips <input>, <label> and other form elements.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $should_print ? print( $html_content ) : $html_content;
 	}
 
@@ -497,9 +499,9 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
+		// Output not escaped intentionally. Breaks the HTML structure when escaped.
 		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
-		// wp_kses_post cannot be used here as it strips <select>, <option> and other form elements.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $should_print ? print( $html_content ) : $html_content;
 	}
 
@@ -567,9 +569,9 @@ class SettingsHelper {
 		<?php
 		$html_content = ob_get_clean();
 
+		// Output not escaped intentionally. Breaks the HTML structure when escaped.
 		// All form elements inside $html_content are pre-escaped during generation (esc_attr, esc_html).
-		// wp_kses_post cannot be used here as it strips <input>, <label> and other form elements.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		return $should_print ? print( $html_content ) : $html_content;
 	}
 }

--- a/includes/Admin/views/required-notice.php
+++ b/includes/Admin/views/required-notice.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="notice notice-error sdevs-install-plugin">
 	<div class="sdevs-notice-icon">
-		<img src="<?php echo esc_url( WP_SUBSCRIPTION_ASSETS . '/images/logo.png' ); ?>" alt="woocommerce-logo" />
+		<img src="<?php echo esc_url( SUBSCRPT_ASSETS . '/images/logo.png' ); ?>" alt="woocommerce-logo" />
 	</div>
 	<div class="sdevs-notice-content">
 		<h2><?php esc_html_e( 'Thanks for using Subscription for WooCommerce', 'subscription' ); ?></h2>

--- a/includes/Admin/views/required-notice.php
+++ b/includes/Admin/views/required-notice.php
@@ -1,3 +1,4 @@
+<?php
 /**
  * WooCommerce dependency notice.
  *

--- a/includes/Admin/views/settings.php
+++ b/includes/Admin/views/settings.php
@@ -14,10 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 subscrpt_include_tailwind_css();
 
 // Add admin settings styles.
-wp_enqueue_style( 'wp-subscription-admin-settings', WP_SUBSCRIPTION_ASSETS . '/css/admin-settings.css', [], WP_SUBSCRIPTION_VERSION );
+wp_enqueue_style( 'wp-subscription-admin-settings', SUBSCRPT_ASSETS . '/css/admin-settings.css', [], SUBSCRPT_VERSION );
 
 // Add admin settings scripts.
-wp_enqueue_script( 'wp-subscription-admin-settings', WP_SUBSCRIPTION_ASSETS . '/js/admin-settings.js', [ 'jquery' ], WP_SUBSCRIPTION_VERSION, true );
+wp_enqueue_script( 'wp-subscription-admin-settings', SUBSCRPT_ASSETS . '/js/admin-settings.js', [ 'jquery' ], SUBSCRPT_VERSION, true );
 
 ?>
 <div class="wp-subscription-admin-content" style="max-width:1240px;margin:32px auto 0 auto">

--- a/includes/Admin/views/subscription-list.php
+++ b/includes/Admin/views/subscription-list.php
@@ -28,7 +28,7 @@ for ( $i = 0; $i < 12; $i++ ) {
 	<form method="post" id="subscriptions-form">
 		<div class="wp-subscription-list-header">
 			<div class="wp-subscription-filters">
-				<?php wp_nonce_field( 'wp_subscription_list_action' ); ?>
+				<?php wp_nonce_field( 'subscrpt_list_action' ); ?>
 				<input type="hidden" name="page" value="wp-subscription" />
 				<select name="subscrpt_status" value="<?php echo esc_attr( $status ); ?>">
 					<option value=""><?php esc_html_e( 'All Status', 'subscription' ); ?></option>

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -30,10 +30,10 @@ class Ajax {
 		include_once ABSPATH . 'wp-admin/includes/misc.php';
 
 		if ( ! class_exists( 'Plugin_Upgrader' ) ) {
-			include ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
+			require_once ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
 		}
 		if ( ! class_exists( 'Plugin_Installer_Skin' ) ) {
-			include ABSPATH . 'wp-admin/includes/class-plugin-installer-skin.php';
+			require_once ABSPATH . 'wp-admin/includes/class-plugin-installer-skin.php';
 		}
 
 		$plugin = 'woocommerce';

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -14,10 +14,8 @@ class Ajax {
 	 * Initialize the class
 	 */
 	public function __construct() {
-		add_action( 'wp_ajax_install_woocommerce_plugin', array( $this, 'install_woocommerce_plugin' ) );
-		add_action( 'wp_ajax_wps_subscription_activate_woocommerce_plugin', array( $this, 'wps_subscription_activate_woocommerce_plugin' ) );
-
-		add_action( 'wp_ajax_activate_woocommerce_plugin', array( $this, 'activate_woocommerce_plugin' ) );
+		add_action( 'wp_ajax_subscrpt_install_woocommerce_plugin', array( $this, 'install_woocommerce_plugin' ) );
+		add_action( 'wp_ajax_subscrpt_activate_woocommerce_plugin', array( $this, 'wps_subscription_activate_woocommerce_plugin' ) );
 	}
 
 	/**

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -39,13 +39,13 @@ class Assets {
 		foreach ( $scripts as $handle => $script ) {
 			$deps      = isset( $script['deps'] ) ? $script['deps'] : false;
 			$in_footer = isset( $script['in_footer'] ) ? $script['in_footer'] : false;
-			$version   = isset( $script['version'] ) ? $script['version'] : WP_SUBSCRIPTION_VERSION;
+			$version   = isset( $script['version'] ) ? $script['version'] : SUBSCRPT_VERSION;
 
 			wp_register_script( $handle, $script['src'], $deps, $version, $in_footer );
 
 			// Register script translations for scripts that use wp-i18n (e.g., block assets).
 			if ( function_exists( 'wp_set_script_translations' ) && 'sdevs_subscrpt_cart_block' === $handle ) {
-				wp_set_script_translations( $handle, 'subscription', WP_SUBSCRIPTION_PATH . '/languages' );
+				wp_set_script_translations( $handle, 'subscription', SUBSCRPT_PATH . '/languages' );
 			}
 		}
 	}
@@ -61,7 +61,7 @@ class Assets {
 		foreach ( $styles as $handle => $style ) {
 			$deps = isset( $style['deps'] ) ? $style['deps'] : false;
 
-			wp_register_style( $handle, $style['src'], $deps, WP_SUBSCRIPTION_VERSION );
+			wp_register_style( $handle, $style['src'], $deps, SUBSCRPT_VERSION );
 		}
 	}
 
@@ -71,14 +71,14 @@ class Assets {
 	 * @return array
 	 */
 	public function get_scripts() {
-		$plugin_js_assets_path = WP_SUBSCRIPTION_ASSETS . '/js/';
+		$plugin_js_assets_path = SUBSCRPT_ASSETS . '/js/';
 
-		$block_script_asset_path = WP_SUBSCRIPTION_PATH . '/build/index.asset.php';
+		$block_script_asset_path = SUBSCRPT_PATH . '/build/index.asset.php';
 		$block_script_asset      = file_exists( $block_script_asset_path )
 			? require $block_script_asset_path
 			: array(
 				'dependencies' => false,
-				'version'      => WP_SUBSCRIPTION_VERSION,
+				'version'      => SUBSCRPT_VERSION,
 			);
 
 		$scripts = array(
@@ -93,7 +93,7 @@ class Assets {
 				'in_footer' => true,
 			),
 			'sdevs_subscrpt_cart_block' => array(
-				'src'       => WP_SUBSCRIPTION_URL . '/build/index.js',
+				'src'       => SUBSCRPT_URL . '/build/index.js',
 				'deps'      => $block_script_asset['dependencies'],
 				'version'   => $block_script_asset['version'],
 				'in_footer' => true,
@@ -109,7 +109,7 @@ class Assets {
 	 * @return array
 	 */
 	public function get_styles() {
-		$plugin_css_assets_path = WP_SUBSCRIPTION_ASSETS . '/css/';
+		$plugin_css_assets_path = SUBSCRPT_ASSETS . '/css/';
 
 		$styles = array(
 			'subscrpt_admin_css'  => array(

--- a/includes/Frontend/ActionController.php
+++ b/includes/Frontend/ActionController.php
@@ -65,9 +65,8 @@ class ActionController {
 		$renewal_actions = apply_filters( 'subscrpt_renewal_actions', array( 'renew', 'renew-on', 'early-renew' ) );
 		if ( in_array( $action, $renewal_actions, true ) && subscrpt_is_max_payments_reached( $subscrpt_id ) ) {
 			wc_add_notice( __( 'This subscription has reached its maximum payment limit and cannot be renewed further.', 'subscription' ), 'error' );
-			// phpcs:ignore
-			echo ( "<script>location.href = '" . wc_get_endpoint_url( $view_subs_endpoint, $subscrpt_id, wc_get_page_permalink( 'myaccount' ) ) . "';</script>" );
-			return;
+			wp_safe_redirect( wc_get_endpoint_url( $view_subs_endpoint, $subscrpt_id, wc_get_page_permalink( 'myaccount' ) ) );
+			exit;
 		}
 
 		if ( 'renew' === $action && ! subscrpt_is_auto_renew_enabled() ) {
@@ -95,15 +94,14 @@ class ActionController {
 			if ( subscrpt_is_max_payments_reached( $subscrpt_id ) &&
 				( strpos( $action, 'renew' ) !== false || strpos( $action, 'renewal' ) !== false ) ) {
 				wc_add_notice( __( 'This subscription has reached its maximum payment limit and cannot be renewed further.', 'subscription' ), 'error' );
-				// phpcs:ignore
-				echo ( "<script>location.href = '" . wc_get_endpoint_url( $view_subs_endpoint, $subscrpt_id, wc_get_page_permalink( 'myaccount' ) ) . "';</script>" );
-				return;
+				wp_safe_redirect( wc_get_endpoint_url( $view_subs_endpoint, $subscrpt_id, wc_get_page_permalink( 'myaccount' ) ) );
+				exit;
 			}
 
 			do_action( 'subscrpt_execute_actions', $subscrpt_id, $action );
 		}
-		// phpcs:ignore
-		echo ( "<script>location.href = '" . wc_get_endpoint_url( $view_subs_endpoint, $subscrpt_id, wc_get_page_permalink( 'myaccount' ) ) . "';</script>" );
+		wp_safe_redirect( wc_get_endpoint_url( $view_subs_endpoint, $subscrpt_id, wc_get_page_permalink( 'myaccount' ) ) );
+		exit;
 	}
 
 	/**
@@ -140,10 +138,7 @@ class ActionController {
 	 * @param String $url URL.
 	 */
 	public function redirect( $url ) {
-		?>
-		<script>
-			window.location.href = '<?php echo esc_url_raw( $url ); ?>';
-		</script>
-		<?php
+		wp_safe_redirect( esc_url( $url ) );
+		exit;
 	}
 }

--- a/includes/Frontend/Checkout.php
+++ b/includes/Frontend/Checkout.php
@@ -165,12 +165,15 @@ class Checkout {
 			return null;
 		}
 
+		$is_new_customer = false;
+
 		// Check if user exists with email.
 		$user    = get_user_by( 'email', $user_info['billing_email'] );
 		$user_id = $user ? $user->ID : 0;
 
 		if ( ! $user_id ) {
-			$username = sanitize_user( current( explode( '@', $user_info['billing_email'] ) ), true );
+			$is_new_customer = true;
+			$username        = sanitize_user( current( explode( '@', $user_info['billing_email'] ) ), true );
 			if ( username_exists( $username ) ) {
 				$username .= '_' . wp_generate_password( 4, false );
 			}
@@ -223,10 +226,14 @@ class Checkout {
 
 		// Login the user.
 		// ? this is temporary, user will be logged out after the checkout.
-		if ( ! is_user_logged_in() ) {
+		if ( ! is_user_logged_in() && $is_new_customer && $user_id ) {
 			// Log the user in
 			wp_set_current_user( $user_id );
-			wp_set_auth_cookie( $user_id );
+			if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
+				wc_set_customer_auth_cookie( $user_id );
+			} else {
+				wp_set_auth_cookie( $user_id );
+			}
 
 			// Optional: trigger login action
 			do_action( 'wp_login', get_userdata( $user_id )->user_login, get_userdata( $user_id ) );
@@ -234,7 +241,7 @@ class Checkout {
 			// Set flag for manual login tracking.
 			set_transient( 'subscrpt_manual_login_' . $user_id, true, 15 * MINUTE_IN_SECONDS );
 
-			wp_subscrpt_write_debug_log( 'Auto-logged in user ID: ' . $user_id . ' after checkout.' );
+			wp_subscrpt_write_debug_log( 'Auto-logged in newly created user ID: ' . $user_id . ' after checkout.' );
 		}
 
 		return $user_id;

--- a/includes/Frontend/Checkout.php
+++ b/includes/Frontend/Checkout.php
@@ -224,10 +224,12 @@ class Checkout {
 			do_action( 'woocommerce_created_customer', $user_id, [], true );
 		}
 
-		// Login the user.
-		// ? this is temporary, user will be logged out after the checkout.
+		// Auto-login the newly created account so the subscription can be associated with the user.
+		// This ONLY runs when $is_new_customer is true — i.e. when wp_insert_user() succeeded
+		// just above in this same request. It never fires for returning/existing users.
+		// wc_set_customer_auth_cookie() is the WooCommerce-sanctioned way to log a customer in
+		// during checkout; wp_set_auth_cookie() is the WP fallback if WC is not available.
 		if ( ! is_user_logged_in() && $is_new_customer && $user_id ) {
-			// Log the user in
 			wp_set_current_user( $user_id );
 			if ( function_exists( 'wc_set_customer_auth_cookie' ) ) {
 				wc_set_customer_auth_cookie( $user_id );
@@ -235,13 +237,10 @@ class Checkout {
 				wp_set_auth_cookie( $user_id );
 			}
 
-			// Optional: trigger login action
-			do_action( 'wp_login', get_userdata( $user_id )->user_login, get_userdata( $user_id ) );
-
 			// Set flag for manual login tracking.
 			set_transient( 'subscrpt_manual_login_' . $user_id, true, 15 * MINUTE_IN_SECONDS );
 
-			wp_subscrpt_write_debug_log( 'Auto-logged in newly created user ID: ' . $user_id . ' after checkout.' );
+			subscrpt_write_debug_log( 'Auto-logged in newly created user ID: ' . $user_id . ' after checkout.' );
 		}
 
 		return $user_id;

--- a/includes/Frontend/MyAccount.php
+++ b/includes/Frontend/MyAccount.php
@@ -237,7 +237,7 @@ class MyAccount {
 				'wp_button_class' => wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '',
 			),
 			'subscription',
-			WP_SUBSCRIPTION_TEMPLATES
+			SUBSCRPT_TEMPLATES
 		);
 	}
 
@@ -318,7 +318,7 @@ class MyAccount {
 				'current_page'    => $current_page,
 			),
 			'subscription',
-			WP_SUBSCRIPTION_TEMPLATES
+			SUBSCRPT_TEMPLATES
 		);
 	}
 

--- a/includes/Illuminate.php
+++ b/includes/Illuminate.php
@@ -54,7 +54,9 @@ class Illuminate {
 			include_once dirname( WC_STRIPE_MAIN_FILE ) . '/includes/compat/trait-wc-stripe-subscriptions.php';
 			include_once dirname( WC_STRIPE_MAIN_FILE ) . '/includes/abstracts/abstract-wc-stripe-payment-gateway.php';
 
-			new Stripe();
+			if ( class_exists( '\WC_Stripe_Payment_Gateway' ) ) {
+				new Stripe();
+			}
 		}
 	}
 

--- a/includes/Illuminate/Gateways/Paypal/Paypal.php
+++ b/includes/Illuminate/Gateways/Paypal/Paypal.php
@@ -422,7 +422,7 @@ class Paypal extends \WC_Payment_Gateway {
 
 		if ( empty( $raw_body ) ) {
 			wp_subscrpt_write_log( 'PayPal webhook data is empty.' );
-			wp_subscrpt_write_debug_log( "PayPal - process_webhook EMPTY \n" . $raw_body );
+			wp_subscrpt_write_debug_log( 'PayPal - process_webhook EMPTY' );
 			wp_die( 'PayPal webhook data is empty.', '400 Bad Request', [ 'response' => 400 ] );
 		}
 
@@ -433,7 +433,7 @@ class Paypal extends \WC_Payment_Gateway {
 		$webhook_data = json_decode( $raw_body, true );
 
 		// Get event type from webhook data.
-		$event = $webhook_data['event_type'] ?? '';
+		$event = isset( $webhook_data['event_type'] ) ? sanitize_text_field( $webhook_data['event_type'] ) : '';
 
 		// Supported transaction events.
 		$transaction_events = [
@@ -454,7 +454,9 @@ class Paypal extends \WC_Payment_Gateway {
 		$order = null;
 
 		// Get transaction ID from webhook data.
-		$transaction_id = $webhook_data['resource']['sale_id'] ?? $webhook_data['resource']['id'] ?? '';
+		$transaction_id = isset( $webhook_data['resource']['sale_id'] )
+			? sanitize_text_field( $webhook_data['resource']['sale_id'] )
+			: ( isset( $webhook_data['resource']['id'] ) ? sanitize_text_field( $webhook_data['resource']['id'] ) : '' );
 
 		// Get order by Transaction ID.
 		if ( ! empty( $transaction_id ) ) {
@@ -466,7 +468,9 @@ class Paypal extends \WC_Payment_Gateway {
 		}
 
 		// Get subscription ID from webhook data.
-		$subscription_id = $webhook_data['resource']['billing_agreement_id'] ?? $webhook_data['resource']['id'] ?? null;
+		$subscription_id = isset( $webhook_data['resource']['billing_agreement_id'] )
+			? sanitize_text_field( $webhook_data['resource']['billing_agreement_id'] )
+			: ( isset( $webhook_data['resource']['id'] ) ? sanitize_text_field( $webhook_data['resource']['id'] ) : null );
 
 		// Get order by Subscription ID.
 		if ( ! $order && ! empty( $subscription_id ) ) {
@@ -551,7 +555,7 @@ class Paypal extends \WC_Payment_Gateway {
 
 		if ( ! $verified ) {
 			wp_subscrpt_write_log( 'PayPal webhook verification failed.' );
-			wp_subscrpt_write_debug_log( 'Webhook verification failed for data: ' . $raw_body );
+			wp_subscrpt_write_debug_log( 'Webhook verification failed for data: ' . sanitize_text_field( $raw_body ) );
 			wp_die( 'Error: PayPal webhook verification failed.', '403 Forbidden', array( 'response' => 403 ) );
 		}
 	}

--- a/includes/Illuminate/Gateways/Paypal/Paypal.php
+++ b/includes/Illuminate/Gateways/Paypal/Paypal.php
@@ -63,7 +63,7 @@ class Paypal extends \WC_Payment_Gateway {
 		$this->method_title       = __( 'PayPal for WPSubscription', 'subscription' );
 		$this->method_description = __( 'Accept wp subscription recurring payments through PayPal. Only WP Subscription is supported.', 'subscription' );
 		$this->supports           = [ 'products', 'subscriptions', 'refunds' ];
-		$this->icon               = apply_filters( 'wp_subscription_paypal_icon', WP_SUBSCRIPTION_URL . '/assets/images/paypal.svg' );
+		$this->icon               = apply_filters( 'wp_subscription_paypal_icon', SUBSCRPT_URL . '/assets/images/paypal.svg' );
 
 		// Load the settings.
 		$this->init_form_fields();
@@ -122,13 +122,13 @@ class Paypal extends \WC_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		// Gateway settings styles.
-		wp_enqueue_style( 'wp-subscription-gateway-settings', WP_SUBSCRIPTION_ASSETS . '/css/gateway.css', [], WP_SUBSCRIPTION_VERSION, 'all' );
+		wp_enqueue_style( 'wp-subscription-gateway-settings', SUBSCRPT_ASSETS . '/css/gateway.css', [], SUBSCRPT_VERSION, 'all' );
 
 		// Settings JS.
-		wp_enqueue_script( 'wp-subscription-gateway-settings-script', WP_SUBSCRIPTION_ASSETS . '/js/gateway.js', [ 'jquery' ], WP_SUBSCRIPTION_VERSION, true );
+		wp_enqueue_script( 'wp-subscription-gateway-settings-script', SUBSCRPT_ASSETS . '/js/gateway.js', [ 'jquery' ], SUBSCRPT_VERSION, true );
 
 		// Live/Sandbox toggle script.
-		wp_enqueue_script( 'wp-subscription-gateway-settings-toggle-script', WP_SUBSCRIPTION_ASSETS . '/js/gateway_options_toggler.js', [ 'jquery' ], WP_SUBSCRIPTION_VERSION, true );
+		wp_enqueue_script( 'wp-subscription-gateway-settings-toggle-script', SUBSCRPT_ASSETS . '/js/gateway_options_toggler.js', [ 'jquery' ], SUBSCRPT_VERSION, true );
 
 		$this->form_fields = [
 			'enabled'                    => [

--- a/includes/Illuminate/Gateways/Paypal/Paypal_Blocks_Integration.php
+++ b/includes/Illuminate/Gateways/Paypal/Paypal_Blocks_Integration.php
@@ -53,13 +53,13 @@ final class Paypal_Blocks_Integration extends AbstractPaymentMethodType {
 	public function get_payment_method_script_handles() {
 		wp_register_script(
 			'wp_subscription_paypal-blocks-integration',
-			WP_SUBSCRIPTION_URL . '/assets/js/wp_subscription_paypal-block.js',
+			SUBSCRPT_URL . '/assets/js/wp_subscription_paypal-block.js',
 			[ 'wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n' ],
 			1,
 			true
 		);
 		if ( function_exists( 'wp_set_script_translations' ) ) {
-			wp_set_script_translations( 'wp_subscription_paypal-blocks-integration', 'subscription', WP_SUBSCRIPTION_PATH . '/languages' );
+			wp_set_script_translations( 'wp_subscription_paypal-blocks-integration', 'subscription', SUBSCRPT_PATH . '/languages' );
 		}
 
 		return array( 'wp_subscription_paypal-blocks-integration' );

--- a/includes/Illuminate/Gateways/Stripe/Stripe.php
+++ b/includes/Illuminate/Gateways/Stripe/Stripe.php
@@ -17,414 +17,412 @@ use SpringDevs\Subscription\Illuminate\Helper;
  *
  * @package SpringDevs\SubscriptionPro\Illuminate
  */
-if ( class_exists( '\WC_Stripe_Payment_Gateway' ) ) {
-	class Stripe extends \WC_Stripe_Payment_Gateway {
+class Stripe extends \WC_Stripe_Payment_Gateway {
 
-		/**
-		 * Subscriptions supported Stripe payment methods.
-		 */
-		public const WPSUBS_SUPPORTED_METHODS = [ 'stripe', 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
+	/**
+	 * Subscriptions supported Stripe payment methods.
+	 */
+	public const WPSUBS_SUPPORTED_METHODS = [ 'stripe', 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
 
-		/**
-		 * Mandate needed methods.
-		 */
-		public const WPSUBS_MANDATE_NEEDED_METHODS = [ 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
+	/**
+	 * Mandate needed methods.
+	 */
+	public const WPSUBS_MANDATE_NEEDED_METHODS = [ 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
 
-		/**
-		 * Initialize the class
-		 */
-		public function __construct() {
-			add_action( 'subscrpt_after_create_renew_order', array( $this, 'after_create_renew_order' ), 10, 3 );
-			add_filter( 'wc_stripe_payment_metadata', array( $this, 'add_payment_metadata' ), 10, 2 );
+	/**
+	 * Initialize the class
+	 */
+	public function __construct() {
+		add_action( 'subscrpt_after_create_renew_order', array( $this, 'after_create_renew_order' ), 10, 3 );
+		add_filter( 'wc_stripe_payment_metadata', array( $this, 'add_payment_metadata' ), 10, 2 );
 
-			// Ensure a reusable payment method is stored for subscription checkouts (needed for iDEAL/SEPA auto-renewals).
-			add_filter( 'wc_stripe_force_save_payment_method', array( $this, 'force_save_payment_method_for_subscriptions' ), 10, 2 );
+		// Ensure a reusable payment method is stored for subscription checkouts (needed for iDEAL/SEPA auto-renewals).
+		add_filter( 'wc_stripe_force_save_payment_method', array( $this, 'force_save_payment_method_for_subscriptions' ), 10, 2 );
 
-			// Modify create intent request to add setup_future_usage and customer when needed.
-			add_filter( 'wc_stripe_generate_create_intent_request', [ $this, 'modify_create_intent_request_for_subscriptions' ], 20, 3 );
+		// Modify create intent request to add setup_future_usage and customer when needed.
+		add_filter( 'wc_stripe_generate_create_intent_request', [ $this, 'modify_create_intent_request_for_subscriptions' ], 20, 3 );
+	}
+
+	/**
+	 * Process stripe auto renewal process.
+	 *
+	 * @param \WC_Order $new_order       New Order.
+	 * @param \WC_Order $old_order       Old Order.
+	 * @param int       $subscription_id Subscription ID.
+	 */
+	public function after_create_renew_order( $new_order, $old_order, $subscription_id ) {
+		$is_auto_renew = get_post_meta( $subscription_id, '_subscrpt_auto_renew', true );
+		$is_auto_renew = in_array( $is_auto_renew, [ 1,'1' ], true );
+
+		$is_global_auto_renew = get_option( 'wp_subscription_stripe_auto_renew', '1' );
+		$is_global_auto_renew = in_array( $is_global_auto_renew, [ 1,'1' ], true );
+
+		$stripe_supported_methods = self::WPSUBS_SUPPORTED_METHODS;
+		$old_method               = $old_order->get_payment_method();
+		$is_stripe_pm             = ! empty( $old_method ) && in_array( $old_method, $stripe_supported_methods, true );
+
+		$has_stripe_meta = ! empty( $old_order->get_meta( '_stripe_customer_id' ) ) || ! empty( $old_order->get_meta( '_stripe_source_id' ) );
+
+		$stripe_enabled = ( ( $is_stripe_pm || $has_stripe_meta ) && $is_auto_renew && $is_global_auto_renew && subscrpt_is_auto_renew_enabled() );
+
+		if ( ! $stripe_enabled ) {
+			$log_message = "Stripe auto renewal not enabled. [ Subscription: {$subscription_id}, Order #{$new_order->get_id()} ]";
+			wp_subscrpt_write_log( $log_message );
+
+			// Log details for debugging.
+			wp_subscrpt_write_debug_log( $log_message );
+			wp_subscrpt_write_debug_log( 'is_auto_renew: ' . ( $is_auto_renew ? 'true' : 'false' ) );
+			wp_subscrpt_write_debug_log( 'is_global_auto_renew: ' . ( $is_global_auto_renew ? 'true' : 'false' ) );
+			wp_subscrpt_write_debug_log( 'is_stripe_payment_method: ' . ( $is_stripe_pm ? 'true' : 'false' ) . ' (old method: ' . $old_method . ')' );
+			wp_subscrpt_write_debug_log( 'has_stripe_meta: ' . ( $has_stripe_meta ? 'true' : 'false' ) );
+			return;
 		}
 
-		/**
-		 * Process stripe auto renewal process.
-		 *
-		 * @param \WC_Order $new_order       New Order.
-		 * @param \WC_Order $old_order       Old Order.
-		 * @param int       $subscription_id Subscription ID.
-		 */
-		public function after_create_renew_order( $new_order, $old_order, $subscription_id ) {
-			$is_auto_renew = get_post_meta( $subscription_id, '_subscrpt_auto_renew', true );
-			$is_auto_renew = in_array( $is_auto_renew, [ 1,'1' ], true );
+		$this->pay_renew_order( $new_order );
+	}
 
-			$is_global_auto_renew = get_option( 'wp_subscription_stripe_auto_renew', '1' );
-			$is_global_auto_renew = in_array( $is_global_auto_renew, [ 1,'1' ], true );
+	/**
+	 * Pay renewal Order
+	 *
+	 * @param \WC_Order $renewal_order Renewal order.
+	 * @throws \WC_Stripe_Exception $e exception.
+	 */
+	public function pay_renew_order( $renewal_order ) {
+		wp_subscrpt_write_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
+		wp_subscrpt_write_debug_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
 
-			$stripe_supported_methods = self::WPSUBS_SUPPORTED_METHODS;
-			$old_method               = $old_order->get_payment_method();
-			$is_stripe_pm             = ! empty( $old_method ) && in_array( $old_method, $stripe_supported_methods, true );
+		try {
+			$stripe_order_helper = new \WC_Stripe_Order_Helper();
+			$stripe_order_helper->validate_minimum_order_amount( $renewal_order );
 
-			$has_stripe_meta = ! empty( $old_order->get_meta( '_stripe_customer_id' ) ) || ! empty( $old_order->get_meta( '_stripe_source_id' ) );
+			$amount   = $renewal_order->get_total();
+			$order_id = $renewal_order->get_id();
 
-			$stripe_enabled = ( ( $is_stripe_pm || $has_stripe_meta ) && $is_auto_renew && $is_global_auto_renew && subscrpt_is_auto_renew_enabled() );
-
-			if ( ! $stripe_enabled ) {
-				$log_message = "Stripe auto renewal not enabled. [ Subscription: {$subscription_id}, Order #{$new_order->get_id()} ]";
-				wp_subscrpt_write_log( $log_message );
-
-				// Log details for debugging.
-				wp_subscrpt_write_debug_log( $log_message );
-				wp_subscrpt_write_debug_log( 'is_auto_renew: ' . ( $is_auto_renew ? 'true' : 'false' ) );
-				wp_subscrpt_write_debug_log( 'is_global_auto_renew: ' . ( $is_global_auto_renew ? 'true' : 'false' ) );
-				wp_subscrpt_write_debug_log( 'is_stripe_payment_method: ' . ( $is_stripe_pm ? 'true' : 'false' ) . ' (old method: ' . $old_method . ')' );
-				wp_subscrpt_write_debug_log( 'has_stripe_meta: ' . ( $has_stripe_meta ? 'true' : 'false' ) );
-				return;
+			// Get source from order.
+			$prepared_source = $this->prepare_order_source( $renewal_order );
+			if ( ! $prepared_source->customer ) {
+				wp_subscrpt_write_log( "Customer not found for renewal order #{$renewal_order->get_id()}. Skipping payment." );
+				return new \WP_Error( 'stripe_error', __( 'Customer not found', 'subscription' ) );
 			}
 
-			$this->pay_renew_order( $new_order );
-		}
+			\WC_Stripe_Logger::info( "Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );
 
-		/**
-		 * Pay renewal Order
-		 *
-		 * @param \WC_Order $renewal_order Renewal order.
-		 * @throws \WC_Stripe_Exception $e exception.
-		 */
-		public function pay_renew_order( $renewal_order ) {
-			wp_subscrpt_write_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
-			wp_subscrpt_write_debug_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
+			$intent = $this->create_intent( $renewal_order, $prepared_source );
 
-			try {
-				$stripe_order_helper = new \WC_Stripe_Order_Helper();
-				$stripe_order_helper->validate_minimum_order_amount( $renewal_order );
-
-				$amount   = $renewal_order->get_total();
-				$order_id = $renewal_order->get_id();
-
-				// Get source from order.
-				$prepared_source = $this->prepare_order_source( $renewal_order );
-				if ( ! $prepared_source->customer ) {
-					wp_subscrpt_write_log( "Customer not found for renewal order #{$renewal_order->get_id()}. Skipping payment." );
-					return new \WP_Error( 'stripe_error', __( 'Customer not found', 'subscription' ) );
+			if ( empty( $intent->error ) ) {
+				$stripe_order_helper->lock_order_payment( $renewal_order, $intent );
+				// Only confirm if Stripe still requires confirmation.
+				if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
+					$intent = $this->confirm_intent( $intent, $renewal_order, $prepared_source );
 				}
+			}
 
-				\WC_Stripe_Logger::info( "Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );
+			if ( ! empty( $intent->error ) ) {
+				$this->maybe_remove_non_existent_customer( $intent->error, $renewal_order );
 
-				$intent = $this->create_intent( $renewal_order, $prepared_source );
-
-				if ( empty( $intent->error ) ) {
-					$stripe_order_helper->lock_order_payment( $renewal_order, $intent );
-					// Only confirm if Stripe still requires confirmation.
-					if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
-						$intent = $this->confirm_intent( $intent, $renewal_order, $prepared_source );
-					}
-				}
-
-				if ( ! empty( $intent->error ) ) {
-					$this->maybe_remove_non_existent_customer( $intent->error, $renewal_order );
-
-					$stripe_order_helper->unlock_order_payment( $renewal_order );
-					$this->throw_localized_message( $intent, $renewal_order );
-				}
-
-				if ( ! empty( $intent ) ) {
-					// Use the last charge within the intent to proceed.
-					$response = $this->get_latest_charge_from_intent( $intent );
-					$this->process_response( $response, $renewal_order );
-				}
 				$stripe_order_helper->unlock_order_payment( $renewal_order );
-
-			} catch ( \WC_Stripe_Exception $e ) {
-				\WC_Stripe_Logger::error( 'Error: ' . $e->getMessage() );
-
-				$log_message = "Error processing renewal order #{$renewal_order->get_id()}: " . $e->getMessage();
-				wp_subscrpt_write_log( $log_message );
-				wp_subscrpt_write_debug_log( $log_message );
-
-				do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
-
-				// Get subscription ID.
-				$subscription    = Helper::get_subscriptions_from_order( $renewal_order->get_id() ?? 0 );
-				$subscription    = reset( $subscription );
-				$subscription_id = $subscription->subscription_id ?? 0;
-
-				// Trigger failed payment mail.
-				do_action( 'subscrpt_payment_failure_email_notification', $subscription_id );
+				$this->throw_localized_message( $intent, $renewal_order );
 			}
+
+			if ( ! empty( $intent ) ) {
+				// Use the last charge within the intent to proceed.
+				$response = $this->get_latest_charge_from_intent( $intent );
+				$this->process_response( $response, $renewal_order );
+			}
+			$stripe_order_helper->unlock_order_payment( $renewal_order );
+
+		} catch ( \WC_Stripe_Exception $e ) {
+			\WC_Stripe_Logger::error( 'Error: ' . $e->getMessage() );
+
+			$log_message = "Error processing renewal order #{$renewal_order->get_id()}: " . $e->getMessage();
+			wp_subscrpt_write_log( $log_message );
+			wp_subscrpt_write_debug_log( $log_message );
+
+			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
+
+			// Get subscription ID.
+			$subscription    = Helper::get_subscriptions_from_order( $renewal_order->get_id() ?? 0 );
+			$subscription    = reset( $subscription );
+			$subscription_id = $subscription->subscription_id ?? 0;
+
+			// Trigger failed payment mail.
+			do_action( 'subscrpt_payment_failure_email_notification', $subscription_id );
+		}
+	}
+
+	/**
+	 * Confirms an intent if it is the `requires_confirmation` state with SEPA mandate support.
+	 *
+	 * @param object    $intent The intent to confirm.
+	 * @param \WC_Order $order The order that the intent is associated with.
+	 * @param object    $prepared_source The source that is being charged.
+	 * @return object Either an error or the updated intent.
+	 */
+	public function confirm_intent( $intent, $order, $prepared_source ) {
+		if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
+			return $intent;
 		}
 
-		/**
-		 * Confirms an intent if it is the `requires_confirmation` state with SEPA mandate support.
-		 *
-		 * @param object    $intent The intent to confirm.
-		 * @param \WC_Order $order The order that the intent is associated with.
-		 * @param object    $prepared_source The source that is being charged.
-		 * @return object Either an error or the updated intent.
-		 */
-		public function confirm_intent( $intent, $order, $prepared_source ) {
-			if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
-				return $intent;
-			}
+		// Build confirm request and include SEPA mandate_data when needed.
+		$confirm_request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, array() );
 
-			// Build confirm request and include SEPA mandate_data when needed.
-			$confirm_request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, array() );
+		$payment_method_types = array();
+		if ( isset( $intent->payment_method_types ) && is_array( $intent->payment_method_types ) ) {
+			$payment_method_types = $intent->payment_method_types;
+		} elseif ( isset( $prepared_source->source_object->type ) ) {
+			$payment_method_types = array( $prepared_source->source_object->type );
+		}
 
-			$payment_method_types = array();
-			if ( isset( $intent->payment_method_types ) && is_array( $intent->payment_method_types ) ) {
-				$payment_method_types = $intent->payment_method_types;
-			} elseif ( isset( $prepared_source->source_object->type ) ) {
-				$payment_method_types = array( $prepared_source->source_object->type );
-			}
-
-			if ( in_array( 'sepa_debit', $payment_method_types, true ) ) {
-				$confirm_request['mandate_data'] = array(
-					'customer_acceptance' => array(
-						'type' => 'offline',
-					),
-				);
-			}
-
-			$level3_data      = $this->get_level3_data_from_order( $order );
-			$confirmed_intent = \WC_Stripe_API::request_with_level3_data(
-				$confirm_request,
-				"payment_intents/$intent->id/confirm",
-				$level3_data,
-				$order
+		if ( in_array( 'sepa_debit', $payment_method_types, true ) ) {
+			$confirm_request['mandate_data'] = array(
+				'customer_acceptance' => array(
+					'type' => 'offline',
+				),
 			);
+		}
 
-			if ( ! empty( $confirmed_intent->error ) ) {
-				return $confirmed_intent;
-			}
+		$level3_data      = $this->get_level3_data_from_order( $order );
+		$confirmed_intent = \WC_Stripe_API::request_with_level3_data(
+			$confirm_request,
+			"payment_intents/$intent->id/confirm",
+			$level3_data,
+			$order
+		);
 
-			// Save a note about the status of the intent.
-			$order_id = $order->get_id();
-			if ( \WC_Stripe_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
-				\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
-			} elseif ( \WC_Stripe_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
-				\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
-			}
-
+		if ( ! empty( $confirmed_intent->error ) ) {
 			return $confirmed_intent;
 		}
 
-		/**
-		 * Generates the request when creating a new payment intent.
-		 *
-		 * @param \WC_Order $order           The order that is being paid for.
-		 * @param object    $prepared_source The source that is used for the payment.
-		 * @return array                    The arguments for the request.
-		 */
-		public function generate_create_intent_request( $order, $prepared_source ) {
-			// The request for a charge contains metadata for the intent.
-			$full_request = $this->generate_payment_request( $order, $prepared_source );
+		// Save a note about the status of the intent.
+		$order_id = $order->get_id();
+		if ( \WC_Stripe_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
+			\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
+		} elseif ( \WC_Stripe_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
+			\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
+		}
 
-			$payment_method_types = array( 'card' );
-			if ( isset( $prepared_source->source_object->type ) ) {
-				$payment_method_types = array( $prepared_source->source_object->type );
-			}
+		return $confirmed_intent;
+	}
 
-			// Determine capture method safely; default to 'automatic'.
-			$requires_automatic_capture = in_array( 'sepa_debit', $payment_method_types, true );
-			$capture_method             = 'automatic';
-			if ( ! $requires_automatic_capture && isset( $full_request['capture'] ) ) {
-				$capture_method = ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual';
-			}
+	/**
+	 * Generates the request when creating a new payment intent.
+	 *
+	 * @param \WC_Order $order           The order that is being paid for.
+	 * @param object    $prepared_source The source that is used for the payment.
+	 * @return array                    The arguments for the request.
+	 */
+	public function generate_create_intent_request( $order, $prepared_source ) {
+		// The request for a charge contains metadata for the intent.
+		$full_request = $this->generate_payment_request( $order, $prepared_source );
 
-			$currency = strtolower( $order->get_currency() );
+		$payment_method_types = array( 'card' );
+		if ( isset( $prepared_source->source_object->type ) ) {
+			$payment_method_types = array( $prepared_source->source_object->type );
+		}
 
-			$request = array(
-				'amount'               => \WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency ),
-				'currency'             => $currency,
-				'description'          => $full_request['description'],
-				'metadata'             => $full_request['metadata'],
-				'capture_method'       => $capture_method,
-				'payment_method_types' => $payment_method_types,
-			);
+		// Determine capture method safely; default to 'automatic'.
+		$requires_automatic_capture = in_array( 'sepa_debit', $payment_method_types, true );
+		$capture_method             = 'automatic';
+		if ( ! $requires_automatic_capture && isset( $full_request['capture'] ) ) {
+			$capture_method = ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual';
+		}
 
-			$request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, $request );
+		$currency = strtolower( $order->get_currency() );
 
-			$force_save_source = apply_filters( 'wc_stripe_force_save_payment_method', false, $order->get_id() );
+		$request = array(
+			'amount'               => \WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency ),
+			'currency'             => $currency,
+			'description'          => $full_request['description'],
+			'metadata'             => $full_request['metadata'],
+			'capture_method'       => $capture_method,
+			'payment_method_types' => $payment_method_types,
+		);
 
-			// Only ask Stripe to set up future usage when we actually have a Stripe customer
-			// (logged-in user or a customer created for this order). For guest + iDEAL, this can
-			// leave orders pending if webhooks are not completing the flow.
-			$has_stripe_customer = ! empty( $prepared_source->customer );
+		$request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, $request );
 
-			if ( $has_stripe_customer && ( $this->save_payment_method_requested() || $this->has_subscription( $order->get_id() ) || $force_save_source ) ) {
-				$request['setup_future_usage']              = 'off_session';
-				$request['metadata']['save_payment_method'] = 'true';
-			}
+		$force_save_source = apply_filters( 'wc_stripe_force_save_payment_method', false, $order->get_id() );
 
-			// For renewal orders, do not set setup_future_usage to avoid mandate_data requirement on confirmation.
-			if ( $this->is_subscription_renewal_order( $order->get_id() ) && isset( $request['setup_future_usage'] ) ) {
-				unset( $request['setup_future_usage'] );
-			}
+		// Only ask Stripe to set up future usage when we actually have a Stripe customer
+		// (logged-in user or a customer created for this order). For guest + iDEAL, this can
+		// leave orders pending if webhooks are not completing the flow.
+		$has_stripe_customer = ! empty( $prepared_source->customer );
 
-			if ( $prepared_source->customer ) {
-				$request['customer'] = $prepared_source->customer;
-			}
+		if ( $has_stripe_customer && ( $this->save_payment_method_requested() || $this->has_subscription( $order->get_id() ) || $force_save_source ) ) {
+			$request['setup_future_usage']              = 'off_session';
+			$request['metadata']['save_payment_method'] = 'true';
+		}
 
-			if ( isset( $full_request['statement_descriptor_suffix'] ) ) {
-				$request['statement_descriptor_suffix'] = $full_request['statement_descriptor_suffix'];
-			}
+		// For renewal orders, do not set setup_future_usage to avoid mandate_data requirement on confirmation.
+		if ( $this->is_subscription_renewal_order( $order->get_id() ) && isset( $request['setup_future_usage'] ) ) {
+			unset( $request['setup_future_usage'] );
+		}
 
-			if ( isset( $full_request['shipping'] ) ) {
-				$request['shipping'] = $full_request['shipping'];
-			}
+		if ( $prepared_source->customer ) {
+			$request['customer'] = $prepared_source->customer;
+		}
 
-			if ( isset( $full_request['receipt_email'] ) ) {
-				$request['receipt_email'] = $full_request['receipt_email'];
-			}
+		if ( isset( $full_request['statement_descriptor_suffix'] ) ) {
+			$request['statement_descriptor_suffix'] = $full_request['statement_descriptor_suffix'];
+		}
 
-			/**
-			 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
-			 *
-			 * @since 3.1.0
-			 * @param array $request
-			 * @param WC_Order $order
-			 * @param object $source
-			 */
-			return apply_filters( 'wc_stripe_generate_create_intent_request', $request, $order, $prepared_source );
+		if ( isset( $full_request['shipping'] ) ) {
+			$request['shipping'] = $full_request['shipping'];
+		}
+
+		if ( isset( $full_request['receipt_email'] ) ) {
+			$request['receipt_email'] = $full_request['receipt_email'];
 		}
 
 		/**
-		 * Add metadata to stripe payment.
+		 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
 		 *
-		 * @param array     $metadata Metadata.
-		 * @param \WC_Order $order Order.
-		 *
-		 * @return array
+		 * @since 3.1.0
+		 * @param array $request
+		 * @param WC_Order $order
+		 * @param object $source
 		 */
-		public function add_payment_metadata( array $metadata, \WC_Order $order ): array {
+		return apply_filters( 'wc_stripe_generate_create_intent_request', $request, $order, $prepared_source );
+	}
 
-			if ( ! subscrpt_is_auto_renew_enabled() ) {
-				return $metadata;
-			}
+	/**
+	 * Add metadata to stripe payment.
+	 *
+	 * @param array     $metadata Metadata.
+	 * @param \WC_Order $order Order.
+	 *
+	 * @return array
+	 */
+	public function add_payment_metadata( array $metadata, \WC_Order $order ): array {
 
-			global $wpdb;
-			$recurring     = false;
-			$renewal_limit = null;
-			foreach ( $order->get_items() as $order_item ) {
-				$table_name = $wpdb->prefix . 'subscrpt_order_relation';
-				// @phpcs:ignore
-				$relation = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE order_id=%d AND order_item_id=%d', array( $table_name, $order->get_id(), $order_item->get_id() ) ) );
-
-				if ( 0 < count( $relation ) ) {
-					$relation      = $relation[0];
-					$is_auto_renew = get_post_meta( (int) $relation->subscription_id, '_subscrpt_auto_renew', true );
-
-					// Get renewal limit from product meta (handles variations)
-					$max_payments  = subscrpt_get_max_payments( (int) $relation->subscription_id );
-					$renewal_limit = $max_payments ? $max_payments : 0;
-
-					if ( in_array( $is_auto_renew, array( 1, '1' ), true ) && in_array( $relation->type, array( 'early-renew', 'renew' ), true ) ) {
-						$recurring = true;
-						break;
-					}
-				}
-			}
-
-			if ( $recurring ) {
-				$metadata += array(
-					'payment_type' => 'recurring',
-				);
-				if ( null !== $renewal_limit ) {
-					$metadata['renewal_limit'] = $renewal_limit;
-				}
-			}
-
+		if ( ! subscrpt_is_auto_renew_enabled() ) {
 			return $metadata;
 		}
 
-		/**
-		 * Mirror of the above for gateways using wc_stripe_force_save_payment_method filter.
-		 *
-		 * @param bool $force    Whether to force save the payment method.
-		 * @param int  $order_id Order ID if available during confirmation.
-		 * @return bool
-		 */
-		public function force_save_payment_method_for_subscriptions( $force, $order_id = 0 ) {
-			if ( $this->cart_has_subscription_items() ) {
-				return true;
-			}
-			if ( $order_id && $this->order_has_subscription_relation( (int) $order_id ) ) {
-				return true;
-			}
-			return $force;
-		}
-
-		/**
-		 * Check if current cart contains subscription items added by this plugin.
-		 *
-		 * @return bool
-		 */
-		private function cart_has_subscription_items(): bool {
-			if ( function_exists( 'WC' ) && WC()->cart ) {
-				$cart_items = WC()->cart->get_cart_contents() ?? [];
-				$recurs     = Helper::get_recurrs_from_cart( $cart_items );
-
-				if ( ! empty( $recurs ) ) {
-					return true;
-				}
-			}
-			return false;
-		}
-
-		/**
-		 * Determine if a given order has subscription relation rows in our mapping table.
-		 *
-		 * @param int $order_id The WooCommerce order ID to check.
-		 * @return bool
-		 */
-		private function order_has_subscription_relation( int $order_id ): bool {
-			$histories = Helper::get_subscriptions_from_order( $order_id );
-			return ! empty( $histories );
-		}
-
-		/**
-		 * Detect if given order id is a renewal order created by this plugin.
-		 *
-		 * @param int $order_id Order ID.
-		 * @return bool
-		 */
-		private function is_subscription_renewal_order( $order_id ) {
-			global $wpdb;
+		global $wpdb;
+		$recurring     = false;
+		$renewal_limit = null;
+		foreach ( $order->get_items() as $order_item ) {
 			$table_name = $wpdb->prefix . 'subscrpt_order_relation';
 			// @phpcs:ignore
-			$row = $wpdb->get_row( $wpdb->prepare( 'SELECT type FROM %i WHERE order_id=%d ORDER BY id DESC', array( $table_name, $order_id ) ) );
-			return ( $row && isset( $row->type ) && 'renew' === $row->type );
-		}
+			$relation = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE order_id=%d AND order_item_id=%d', array( $table_name, $order->get_id(), $order_item->get_id() ) ) );
 
-		/**
-		 * Modify create intent request to add setup_future_usage and customer when needed.
-		 *
-		 * @param array     $request         The arguments for the request.
-		 * @param \WC_Order $order           The order that is being paid for.
-		 * @param object    $prepared_source The source that is used for the payment.
-		 */
-		public function modify_create_intent_request_for_subscriptions( $request, $order, $prepared_source ) {
-			$is_subscription_order = $this->order_has_subscription_relation( $order->get_id() );
-			if ( ! $is_subscription_order ) {
-				return $request;
-			}
+			if ( 0 < count( $relation ) ) {
+				$relation      = $relation[0];
+				$is_auto_renew = get_post_meta( (int) $relation->subscription_id, '_subscrpt_auto_renew', true );
 
-			$request['setup_future_usage']              = 'off_session';
-			$request['metadata']['save_payment_method'] = 'true';
+				// Get renewal limit from product meta (handles variations)
+				$max_payments  = subscrpt_get_max_payments( (int) $relation->subscription_id );
+				$renewal_limit = $max_payments ? $max_payments : 0;
 
-			// Ensure we have a customer for future payments
-			if ( ! empty( $prepared_source->customer ) ) {
-				$request['customer'] = $prepared_source->customer;
-			}
-
-			if ( isset( $request['confirm'] ) && true === $request['confirm'] ) {
-				if ( in_array( $order->get_payment_method(), self::WPSUBS_MANDATE_NEEDED_METHODS, true ) ) {
-					$request['mandate_data'] = [
-						'customer_acceptance' => [
-							'type' => 'offline',
-						],
-					];
+				if ( in_array( $is_auto_renew, array( 1, '1' ), true ) && in_array( $relation->type, array( 'early-renew', 'renew' ), true ) ) {
+					$recurring = true;
+					break;
 				}
 			}
+		}
 
+		if ( $recurring ) {
+			$metadata += array(
+				'payment_type' => 'recurring',
+			);
+			if ( null !== $renewal_limit ) {
+				$metadata['renewal_limit'] = $renewal_limit;
+			}
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Mirror of the above for gateways using wc_stripe_force_save_payment_method filter.
+	 *
+	 * @param bool $force    Whether to force save the payment method.
+	 * @param int  $order_id Order ID if available during confirmation.
+	 * @return bool
+	 */
+	public function force_save_payment_method_for_subscriptions( $force, $order_id = 0 ) {
+		if ( $this->cart_has_subscription_items() ) {
+			return true;
+		}
+		if ( $order_id && $this->order_has_subscription_relation( (int) $order_id ) ) {
+			return true;
+		}
+		return $force;
+	}
+
+	/**
+	 * Check if current cart contains subscription items added by this plugin.
+	 *
+	 * @return bool
+	 */
+	private function cart_has_subscription_items(): bool {
+		if ( function_exists( 'WC' ) && WC()->cart ) {
+			$cart_items = WC()->cart->get_cart_contents() ?? [];
+			$recurs     = Helper::get_recurrs_from_cart( $cart_items );
+
+			if ( ! empty( $recurs ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if a given order has subscription relation rows in our mapping table.
+	 *
+	 * @param int $order_id The WooCommerce order ID to check.
+	 * @return bool
+	 */
+	private function order_has_subscription_relation( int $order_id ): bool {
+		$histories = Helper::get_subscriptions_from_order( $order_id );
+		return ! empty( $histories );
+	}
+
+	/**
+	 * Detect if given order id is a renewal order created by this plugin.
+	 *
+	 * @param int $order_id Order ID.
+	 * @return bool
+	 */
+	private function is_subscription_renewal_order( $order_id ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'subscrpt_order_relation';
+		// @phpcs:ignore
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT type FROM %i WHERE order_id=%d ORDER BY id DESC', array( $table_name, $order_id ) ) );
+		return ( $row && isset( $row->type ) && 'renew' === $row->type );
+	}
+
+	/**
+	 * Modify create intent request to add setup_future_usage and customer when needed.
+	 *
+	 * @param array     $request         The arguments for the request.
+	 * @param \WC_Order $order           The order that is being paid for.
+	 * @param object    $prepared_source The source that is used for the payment.
+	 */
+	public function modify_create_intent_request_for_subscriptions( $request, $order, $prepared_source ) {
+		$is_subscription_order = $this->order_has_subscription_relation( $order->get_id() );
+		if ( ! $is_subscription_order ) {
 			return $request;
 		}
+
+		$request['setup_future_usage']              = 'off_session';
+		$request['metadata']['save_payment_method'] = 'true';
+
+		// Ensure we have a customer for future payments
+		if ( ! empty( $prepared_source->customer ) ) {
+			$request['customer'] = $prepared_source->customer;
+		}
+
+		if ( isset( $request['confirm'] ) && true === $request['confirm'] ) {
+			if ( in_array( $order->get_payment_method(), self::WPSUBS_MANDATE_NEEDED_METHODS, true ) ) {
+				$request['mandate_data'] = [
+					'customer_acceptance' => [
+						'type' => 'offline',
+					],
+				];
+			}
+		}
+
+		return $request;
 	}
-} // end class_exists guard
+}

--- a/includes/Illuminate/Gateways/Stripe/Stripe.php
+++ b/includes/Illuminate/Gateways/Stripe/Stripe.php
@@ -17,412 +17,414 @@ use SpringDevs\Subscription\Illuminate\Helper;
  *
  * @package SpringDevs\SubscriptionPro\Illuminate
  */
-class Stripe extends \WC_Stripe_Payment_Gateway {
+if ( class_exists( '\WC_Stripe_Payment_Gateway' ) ) {
+	class Stripe extends \WC_Stripe_Payment_Gateway {
 
-	/**
-	 * Subscriptions supported Stripe payment methods.
-	 */
-	public const WPSUBS_SUPPORTED_METHODS = [ 'stripe', 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
+		/**
+		 * Subscriptions supported Stripe payment methods.
+		 */
+		public const WPSUBS_SUPPORTED_METHODS = [ 'stripe', 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
 
-	/**
-	 * Mandate needed methods.
-	 */
-	public const WPSUBS_MANDATE_NEEDED_METHODS = [ 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
+		/**
+		 * Mandate needed methods.
+		 */
+		public const WPSUBS_MANDATE_NEEDED_METHODS = [ 'stripe_ideal', 'stripe_sepa', 'sepa_debit', 'stripe_bancontact' ];
 
-	/**
-	 * Initialize the class
-	 */
-	public function __construct() {
-		add_action( 'subscrpt_after_create_renew_order', array( $this, 'after_create_renew_order' ), 10, 3 );
-		add_filter( 'wc_stripe_payment_metadata', array( $this, 'add_payment_metadata' ), 10, 2 );
+		/**
+		 * Initialize the class
+		 */
+		public function __construct() {
+			add_action( 'subscrpt_after_create_renew_order', array( $this, 'after_create_renew_order' ), 10, 3 );
+			add_filter( 'wc_stripe_payment_metadata', array( $this, 'add_payment_metadata' ), 10, 2 );
 
-		// Ensure a reusable payment method is stored for subscription checkouts (needed for iDEAL/SEPA auto-renewals).
-		add_filter( 'wc_stripe_force_save_payment_method', array( $this, 'force_save_payment_method_for_subscriptions' ), 10, 2 );
+			// Ensure a reusable payment method is stored for subscription checkouts (needed for iDEAL/SEPA auto-renewals).
+			add_filter( 'wc_stripe_force_save_payment_method', array( $this, 'force_save_payment_method_for_subscriptions' ), 10, 2 );
 
-		// Modify create intent request to add setup_future_usage and customer when needed.
-		add_filter( 'wc_stripe_generate_create_intent_request', [ $this, 'modify_create_intent_request_for_subscriptions' ], 20, 3 );
-	}
-
-	/**
-	 * Process stripe auto renewal process.
-	 *
-	 * @param \WC_Order $new_order       New Order.
-	 * @param \WC_Order $old_order       Old Order.
-	 * @param int       $subscription_id Subscription ID.
-	 */
-	public function after_create_renew_order( $new_order, $old_order, $subscription_id ) {
-		$is_auto_renew = get_post_meta( $subscription_id, '_subscrpt_auto_renew', true );
-		$is_auto_renew = in_array( $is_auto_renew, [ 1,'1' ], true );
-
-		$is_global_auto_renew = get_option( 'wp_subscription_stripe_auto_renew', '1' );
-		$is_global_auto_renew = in_array( $is_global_auto_renew, [ 1,'1' ], true );
-
-		$stripe_supported_methods = self::WPSUBS_SUPPORTED_METHODS;
-		$old_method               = $old_order->get_payment_method();
-		$is_stripe_pm             = ! empty( $old_method ) && in_array( $old_method, $stripe_supported_methods, true );
-
-		$has_stripe_meta = ! empty( $old_order->get_meta( '_stripe_customer_id' ) ) || ! empty( $old_order->get_meta( '_stripe_source_id' ) );
-
-		$stripe_enabled = ( ( $is_stripe_pm || $has_stripe_meta ) && $is_auto_renew && $is_global_auto_renew && subscrpt_is_auto_renew_enabled() );
-
-		if ( ! $stripe_enabled ) {
-			$log_message = "Stripe auto renewal not enabled. [ Subscription: {$subscription_id}, Order #{$new_order->get_id()} ]";
-			wp_subscrpt_write_log( $log_message );
-
-			// Log details for debugging.
-			wp_subscrpt_write_debug_log( $log_message );
-			wp_subscrpt_write_debug_log( 'is_auto_renew: ' . ( $is_auto_renew ? 'true' : 'false' ) );
-			wp_subscrpt_write_debug_log( 'is_global_auto_renew: ' . ( $is_global_auto_renew ? 'true' : 'false' ) );
-			wp_subscrpt_write_debug_log( 'is_stripe_payment_method: ' . ( $is_stripe_pm ? 'true' : 'false' ) . ' (old method: ' . $old_method . ')' );
-			wp_subscrpt_write_debug_log( 'has_stripe_meta: ' . ( $has_stripe_meta ? 'true' : 'false' ) );
-			return;
-		}
-
-		$this->pay_renew_order( $new_order );
-	}
-
-	/**
-	 * Pay renewal Order
-	 *
-	 * @param \WC_Order $renewal_order Renewal order.
-	 * @throws \WC_Stripe_Exception $e exception.
-	 */
-	public function pay_renew_order( $renewal_order ) {
-		wp_subscrpt_write_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
-		wp_subscrpt_write_debug_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
-
-		try {
-			$stripe_order_helper = new \WC_Stripe_Order_Helper();
-			$stripe_order_helper->validate_minimum_order_amount( $renewal_order );
-
-			$amount   = $renewal_order->get_total();
-			$order_id = $renewal_order->get_id();
-
-			// Get source from order.
-			$prepared_source = $this->prepare_order_source( $renewal_order );
-			if ( ! $prepared_source->customer ) {
-				wp_subscrpt_write_log( "Customer not found for renewal order #{$renewal_order->get_id()}. Skipping payment." );
-				return new \WP_Error( 'stripe_error', __( 'Customer not found', 'subscription' ) );
-			}
-
-			\WC_Stripe_Logger::info( "Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );
-
-			$intent = $this->create_intent( $renewal_order, $prepared_source );
-
-			if ( empty( $intent->error ) ) {
-				$stripe_order_helper->lock_order_payment( $renewal_order, $intent );
-				// Only confirm if Stripe still requires confirmation.
-				if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
-					$intent = $this->confirm_intent( $intent, $renewal_order, $prepared_source );
-				}
-			}
-
-			if ( ! empty( $intent->error ) ) {
-				$this->maybe_remove_non_existent_customer( $intent->error, $renewal_order );
-
-				$stripe_order_helper->unlock_order_payment( $renewal_order );
-				$this->throw_localized_message( $intent, $renewal_order );
-			}
-
-			if ( ! empty( $intent ) ) {
-				// Use the last charge within the intent to proceed.
-				$response = $this->get_latest_charge_from_intent( $intent );
-				$this->process_response( $response, $renewal_order );
-			}
-			$stripe_order_helper->unlock_order_payment( $renewal_order );
-
-		} catch ( \WC_Stripe_Exception $e ) {
-			\WC_Stripe_Logger::error( 'Error: ' . $e->getMessage() );
-
-			$log_message = "Error processing renewal order #{$renewal_order->get_id()}: " . $e->getMessage();
-			wp_subscrpt_write_log( $log_message );
-			wp_subscrpt_write_debug_log( $log_message );
-
-			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
-
-			// Get subscription ID.
-			$subscription    = Helper::get_subscriptions_from_order( $renewal_order->get_id() ?? 0 );
-			$subscription    = reset( $subscription );
-			$subscription_id = $subscription->subscription_id ?? 0;
-
-			// Trigger failed payment mail.
-			do_action( 'subscrpt_payment_failure_email_notification', $subscription_id );
-		}
-	}
-
-	/**
-	 * Confirms an intent if it is the `requires_confirmation` state with SEPA mandate support.
-	 *
-	 * @param object    $intent The intent to confirm.
-	 * @param \WC_Order $order The order that the intent is associated with.
-	 * @param object    $prepared_source The source that is being charged.
-	 * @return object Either an error or the updated intent.
-	 */
-	public function confirm_intent( $intent, $order, $prepared_source ) {
-		if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
-			return $intent;
-		}
-
-		// Build confirm request and include SEPA mandate_data when needed.
-		$confirm_request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, array() );
-
-		$payment_method_types = array();
-		if ( isset( $intent->payment_method_types ) && is_array( $intent->payment_method_types ) ) {
-			$payment_method_types = $intent->payment_method_types;
-		} elseif ( isset( $prepared_source->source_object->type ) ) {
-			$payment_method_types = array( $prepared_source->source_object->type );
-		}
-
-		if ( in_array( 'sepa_debit', $payment_method_types, true ) ) {
-			$confirm_request['mandate_data'] = array(
-				'customer_acceptance' => array(
-					'type' => 'offline',
-				),
-			);
-		}
-
-		$level3_data      = $this->get_level3_data_from_order( $order );
-		$confirmed_intent = \WC_Stripe_API::request_with_level3_data(
-			$confirm_request,
-			"payment_intents/$intent->id/confirm",
-			$level3_data,
-			$order
-		);
-
-		if ( ! empty( $confirmed_intent->error ) ) {
-			return $confirmed_intent;
-		}
-
-		// Save a note about the status of the intent.
-		$order_id = $order->get_id();
-		if ( \WC_Stripe_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
-			\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
-		} elseif ( \WC_Stripe_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
-			\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
-		}
-
-		return $confirmed_intent;
-	}
-
-	/**
-	 * Generates the request when creating a new payment intent.
-	 *
-	 * @param \WC_Order $order           The order that is being paid for.
-	 * @param object    $prepared_source The source that is used for the payment.
-	 * @return array                    The arguments for the request.
-	 */
-	public function generate_create_intent_request( $order, $prepared_source ) {
-		// The request for a charge contains metadata for the intent.
-		$full_request = $this->generate_payment_request( $order, $prepared_source );
-
-		$payment_method_types = array( 'card' );
-		if ( isset( $prepared_source->source_object->type ) ) {
-			$payment_method_types = array( $prepared_source->source_object->type );
-		}
-
-		// Determine capture method safely; default to 'automatic'.
-		$requires_automatic_capture = in_array( 'sepa_debit', $payment_method_types, true );
-		$capture_method             = 'automatic';
-		if ( ! $requires_automatic_capture && isset( $full_request['capture'] ) ) {
-			$capture_method = ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual';
-		}
-
-		$currency = strtolower( $order->get_currency() );
-
-		$request = array(
-			'amount'               => \WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency ),
-			'currency'             => $currency,
-			'description'          => $full_request['description'],
-			'metadata'             => $full_request['metadata'],
-			'capture_method'       => $capture_method,
-			'payment_method_types' => $payment_method_types,
-		);
-
-		$request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, $request );
-
-		$force_save_source = apply_filters( 'wc_stripe_force_save_payment_method', false, $order->get_id() );
-
-		// Only ask Stripe to set up future usage when we actually have a Stripe customer
-		// (logged-in user or a customer created for this order). For guest + iDEAL, this can
-		// leave orders pending if webhooks are not completing the flow.
-		$has_stripe_customer = ! empty( $prepared_source->customer );
-
-		if ( $has_stripe_customer && ( $this->save_payment_method_requested() || $this->has_subscription( $order->get_id() ) || $force_save_source ) ) {
-			$request['setup_future_usage']              = 'off_session';
-			$request['metadata']['save_payment_method'] = 'true';
-		}
-
-		// For renewal orders, do not set setup_future_usage to avoid mandate_data requirement on confirmation.
-		if ( $this->is_subscription_renewal_order( $order->get_id() ) && isset( $request['setup_future_usage'] ) ) {
-			unset( $request['setup_future_usage'] );
-		}
-
-		if ( $prepared_source->customer ) {
-			$request['customer'] = $prepared_source->customer;
-		}
-
-		if ( isset( $full_request['statement_descriptor_suffix'] ) ) {
-			$request['statement_descriptor_suffix'] = $full_request['statement_descriptor_suffix'];
-		}
-
-		if ( isset( $full_request['shipping'] ) ) {
-			$request['shipping'] = $full_request['shipping'];
-		}
-
-		if ( isset( $full_request['receipt_email'] ) ) {
-			$request['receipt_email'] = $full_request['receipt_email'];
+			// Modify create intent request to add setup_future_usage and customer when needed.
+			add_filter( 'wc_stripe_generate_create_intent_request', [ $this, 'modify_create_intent_request_for_subscriptions' ], 20, 3 );
 		}
 
 		/**
-		 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
+		 * Process stripe auto renewal process.
 		 *
-		 * @since 3.1.0
-		 * @param array $request
-		 * @param WC_Order $order
-		 * @param object $source
+		 * @param \WC_Order $new_order       New Order.
+		 * @param \WC_Order $old_order       Old Order.
+		 * @param int       $subscription_id Subscription ID.
 		 */
-		return apply_filters( 'wc_stripe_generate_create_intent_request', $request, $order, $prepared_source );
-	}
+		public function after_create_renew_order( $new_order, $old_order, $subscription_id ) {
+			$is_auto_renew = get_post_meta( $subscription_id, '_subscrpt_auto_renew', true );
+			$is_auto_renew = in_array( $is_auto_renew, [ 1,'1' ], true );
 
-	/**
-	 * Add metadata to stripe payment.
-	 *
-	 * @param array     $metadata Metadata.
-	 * @param \WC_Order $order Order.
-	 *
-	 * @return array
-	 */
-	public function add_payment_metadata( array $metadata, \WC_Order $order ): array {
+			$is_global_auto_renew = get_option( 'wp_subscription_stripe_auto_renew', '1' );
+			$is_global_auto_renew = in_array( $is_global_auto_renew, [ 1,'1' ], true );
 
-		if ( ! subscrpt_is_auto_renew_enabled() ) {
+			$stripe_supported_methods = self::WPSUBS_SUPPORTED_METHODS;
+			$old_method               = $old_order->get_payment_method();
+			$is_stripe_pm             = ! empty( $old_method ) && in_array( $old_method, $stripe_supported_methods, true );
+
+			$has_stripe_meta = ! empty( $old_order->get_meta( '_stripe_customer_id' ) ) || ! empty( $old_order->get_meta( '_stripe_source_id' ) );
+
+			$stripe_enabled = ( ( $is_stripe_pm || $has_stripe_meta ) && $is_auto_renew && $is_global_auto_renew && subscrpt_is_auto_renew_enabled() );
+
+			if ( ! $stripe_enabled ) {
+				$log_message = "Stripe auto renewal not enabled. [ Subscription: {$subscription_id}, Order #{$new_order->get_id()} ]";
+				wp_subscrpt_write_log( $log_message );
+
+				// Log details for debugging.
+				wp_subscrpt_write_debug_log( $log_message );
+				wp_subscrpt_write_debug_log( 'is_auto_renew: ' . ( $is_auto_renew ? 'true' : 'false' ) );
+				wp_subscrpt_write_debug_log( 'is_global_auto_renew: ' . ( $is_global_auto_renew ? 'true' : 'false' ) );
+				wp_subscrpt_write_debug_log( 'is_stripe_payment_method: ' . ( $is_stripe_pm ? 'true' : 'false' ) . ' (old method: ' . $old_method . ')' );
+				wp_subscrpt_write_debug_log( 'has_stripe_meta: ' . ( $has_stripe_meta ? 'true' : 'false' ) );
+				return;
+			}
+
+			$this->pay_renew_order( $new_order );
+		}
+
+		/**
+		 * Pay renewal Order
+		 *
+		 * @param \WC_Order $renewal_order Renewal order.
+		 * @throws \WC_Stripe_Exception $e exception.
+		 */
+		public function pay_renew_order( $renewal_order ) {
+			wp_subscrpt_write_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
+			wp_subscrpt_write_debug_log( "Processing renewal order #{$renewal_order->get_id()} for payment." );
+
+			try {
+				$stripe_order_helper = new \WC_Stripe_Order_Helper();
+				$stripe_order_helper->validate_minimum_order_amount( $renewal_order );
+
+				$amount   = $renewal_order->get_total();
+				$order_id = $renewal_order->get_id();
+
+				// Get source from order.
+				$prepared_source = $this->prepare_order_source( $renewal_order );
+				if ( ! $prepared_source->customer ) {
+					wp_subscrpt_write_log( "Customer not found for renewal order #{$renewal_order->get_id()}. Skipping payment." );
+					return new \WP_Error( 'stripe_error', __( 'Customer not found', 'subscription' ) );
+				}
+
+				\WC_Stripe_Logger::info( "Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );
+
+				$intent = $this->create_intent( $renewal_order, $prepared_source );
+
+				if ( empty( $intent->error ) ) {
+					$stripe_order_helper->lock_order_payment( $renewal_order, $intent );
+					// Only confirm if Stripe still requires confirmation.
+					if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
+						$intent = $this->confirm_intent( $intent, $renewal_order, $prepared_source );
+					}
+				}
+
+				if ( ! empty( $intent->error ) ) {
+					$this->maybe_remove_non_existent_customer( $intent->error, $renewal_order );
+
+					$stripe_order_helper->unlock_order_payment( $renewal_order );
+					$this->throw_localized_message( $intent, $renewal_order );
+				}
+
+				if ( ! empty( $intent ) ) {
+					// Use the last charge within the intent to proceed.
+					$response = $this->get_latest_charge_from_intent( $intent );
+					$this->process_response( $response, $renewal_order );
+				}
+				$stripe_order_helper->unlock_order_payment( $renewal_order );
+
+			} catch ( \WC_Stripe_Exception $e ) {
+				\WC_Stripe_Logger::error( 'Error: ' . $e->getMessage() );
+
+				$log_message = "Error processing renewal order #{$renewal_order->get_id()}: " . $e->getMessage();
+				wp_subscrpt_write_log( $log_message );
+				wp_subscrpt_write_debug_log( $log_message );
+
+				do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
+
+				// Get subscription ID.
+				$subscription    = Helper::get_subscriptions_from_order( $renewal_order->get_id() ?? 0 );
+				$subscription    = reset( $subscription );
+				$subscription_id = $subscription->subscription_id ?? 0;
+
+				// Trigger failed payment mail.
+				do_action( 'subscrpt_payment_failure_email_notification', $subscription_id );
+			}
+		}
+
+		/**
+		 * Confirms an intent if it is the `requires_confirmation` state with SEPA mandate support.
+		 *
+		 * @param object    $intent The intent to confirm.
+		 * @param \WC_Order $order The order that the intent is associated with.
+		 * @param object    $prepared_source The source that is being charged.
+		 * @return object Either an error or the updated intent.
+		 */
+		public function confirm_intent( $intent, $order, $prepared_source ) {
+			if ( \WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
+				return $intent;
+			}
+
+			// Build confirm request and include SEPA mandate_data when needed.
+			$confirm_request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, array() );
+
+			$payment_method_types = array();
+			if ( isset( $intent->payment_method_types ) && is_array( $intent->payment_method_types ) ) {
+				$payment_method_types = $intent->payment_method_types;
+			} elseif ( isset( $prepared_source->source_object->type ) ) {
+				$payment_method_types = array( $prepared_source->source_object->type );
+			}
+
+			if ( in_array( 'sepa_debit', $payment_method_types, true ) ) {
+				$confirm_request['mandate_data'] = array(
+					'customer_acceptance' => array(
+						'type' => 'offline',
+					),
+				);
+			}
+
+			$level3_data      = $this->get_level3_data_from_order( $order );
+			$confirmed_intent = \WC_Stripe_API::request_with_level3_data(
+				$confirm_request,
+				"payment_intents/$intent->id/confirm",
+				$level3_data,
+				$order
+			);
+
+			if ( ! empty( $confirmed_intent->error ) ) {
+				return $confirmed_intent;
+			}
+
+			// Save a note about the status of the intent.
+			$order_id = $order->get_id();
+			if ( \WC_Stripe_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
+				\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
+			} elseif ( \WC_Stripe_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
+				\WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
+			}
+
+			return $confirmed_intent;
+		}
+
+		/**
+		 * Generates the request when creating a new payment intent.
+		 *
+		 * @param \WC_Order $order           The order that is being paid for.
+		 * @param object    $prepared_source The source that is used for the payment.
+		 * @return array                    The arguments for the request.
+		 */
+		public function generate_create_intent_request( $order, $prepared_source ) {
+			// The request for a charge contains metadata for the intent.
+			$full_request = $this->generate_payment_request( $order, $prepared_source );
+
+			$payment_method_types = array( 'card' );
+			if ( isset( $prepared_source->source_object->type ) ) {
+				$payment_method_types = array( $prepared_source->source_object->type );
+			}
+
+			// Determine capture method safely; default to 'automatic'.
+			$requires_automatic_capture = in_array( 'sepa_debit', $payment_method_types, true );
+			$capture_method             = 'automatic';
+			if ( ! $requires_automatic_capture && isset( $full_request['capture'] ) ) {
+				$capture_method = ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual';
+			}
+
+			$currency = strtolower( $order->get_currency() );
+
+			$request = array(
+				'amount'               => \WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency ),
+				'currency'             => $currency,
+				'description'          => $full_request['description'],
+				'metadata'             => $full_request['metadata'],
+				'capture_method'       => $capture_method,
+				'payment_method_types' => $payment_method_types,
+			);
+
+			$request = \WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, $request );
+
+			$force_save_source = apply_filters( 'wc_stripe_force_save_payment_method', false, $order->get_id() );
+
+			// Only ask Stripe to set up future usage when we actually have a Stripe customer
+			// (logged-in user or a customer created for this order). For guest + iDEAL, this can
+			// leave orders pending if webhooks are not completing the flow.
+			$has_stripe_customer = ! empty( $prepared_source->customer );
+
+			if ( $has_stripe_customer && ( $this->save_payment_method_requested() || $this->has_subscription( $order->get_id() ) || $force_save_source ) ) {
+				$request['setup_future_usage']              = 'off_session';
+				$request['metadata']['save_payment_method'] = 'true';
+			}
+
+			// For renewal orders, do not set setup_future_usage to avoid mandate_data requirement on confirmation.
+			if ( $this->is_subscription_renewal_order( $order->get_id() ) && isset( $request['setup_future_usage'] ) ) {
+				unset( $request['setup_future_usage'] );
+			}
+
+			if ( $prepared_source->customer ) {
+				$request['customer'] = $prepared_source->customer;
+			}
+
+			if ( isset( $full_request['statement_descriptor_suffix'] ) ) {
+				$request['statement_descriptor_suffix'] = $full_request['statement_descriptor_suffix'];
+			}
+
+			if ( isset( $full_request['shipping'] ) ) {
+				$request['shipping'] = $full_request['shipping'];
+			}
+
+			if ( isset( $full_request['receipt_email'] ) ) {
+				$request['receipt_email'] = $full_request['receipt_email'];
+			}
+
+			/**
+			 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
+			 *
+			 * @since 3.1.0
+			 * @param array $request
+			 * @param WC_Order $order
+			 * @param object $source
+			 */
+			return apply_filters( 'wc_stripe_generate_create_intent_request', $request, $order, $prepared_source );
+		}
+
+		/**
+		 * Add metadata to stripe payment.
+		 *
+		 * @param array     $metadata Metadata.
+		 * @param \WC_Order $order Order.
+		 *
+		 * @return array
+		 */
+		public function add_payment_metadata( array $metadata, \WC_Order $order ): array {
+
+			if ( ! subscrpt_is_auto_renew_enabled() ) {
+				return $metadata;
+			}
+
+			global $wpdb;
+			$recurring     = false;
+			$renewal_limit = null;
+			foreach ( $order->get_items() as $order_item ) {
+				$table_name = $wpdb->prefix . 'subscrpt_order_relation';
+				// @phpcs:ignore
+				$relation = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE order_id=%d AND order_item_id=%d', array( $table_name, $order->get_id(), $order_item->get_id() ) ) );
+
+				if ( 0 < count( $relation ) ) {
+					$relation      = $relation[0];
+					$is_auto_renew = get_post_meta( (int) $relation->subscription_id, '_subscrpt_auto_renew', true );
+
+					// Get renewal limit from product meta (handles variations)
+					$max_payments  = subscrpt_get_max_payments( (int) $relation->subscription_id );
+					$renewal_limit = $max_payments ? $max_payments : 0;
+
+					if ( in_array( $is_auto_renew, array( 1, '1' ), true ) && in_array( $relation->type, array( 'early-renew', 'renew' ), true ) ) {
+						$recurring = true;
+						break;
+					}
+				}
+			}
+
+			if ( $recurring ) {
+				$metadata += array(
+					'payment_type' => 'recurring',
+				);
+				if ( null !== $renewal_limit ) {
+					$metadata['renewal_limit'] = $renewal_limit;
+				}
+			}
+
 			return $metadata;
 		}
 
-		global $wpdb;
-		$recurring     = false;
-		$renewal_limit = null;
-		foreach ( $order->get_items() as $order_item ) {
-			$table_name = $wpdb->prefix . 'subscrpt_order_relation';
-			// @phpcs:ignore
-			$relation = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE order_id=%d AND order_item_id=%d', array( $table_name, $order->get_id(), $order_item->get_id() ) ) );
-
-			if ( 0 < count( $relation ) ) {
-				$relation      = $relation[0];
-				$is_auto_renew = get_post_meta( (int) $relation->subscription_id, '_subscrpt_auto_renew', true );
-
-				// Get renewal limit from product meta (handles variations)
-				$max_payments  = subscrpt_get_max_payments( (int) $relation->subscription_id );
-				$renewal_limit = $max_payments ? $max_payments : 0;
-
-				if ( in_array( $is_auto_renew, array( 1, '1' ), true ) && in_array( $relation->type, array( 'early-renew', 'renew' ), true ) ) {
-					$recurring = true;
-					break;
-				}
-			}
-		}
-
-		if ( $recurring ) {
-			$metadata += array(
-				'payment_type' => 'recurring',
-			);
-			if ( null !== $renewal_limit ) {
-				$metadata['renewal_limit'] = $renewal_limit;
-			}
-		}
-
-		return $metadata;
-	}
-
-	/**
-	 * Mirror of the above for gateways using wc_stripe_force_save_payment_method filter.
-	 *
-	 * @param bool $force    Whether to force save the payment method.
-	 * @param int  $order_id Order ID if available during confirmation.
-	 * @return bool
-	 */
-	public function force_save_payment_method_for_subscriptions( $force, $order_id = 0 ) {
-		if ( $this->cart_has_subscription_items() ) {
-			return true;
-		}
-		if ( $order_id && $this->order_has_subscription_relation( (int) $order_id ) ) {
-			return true;
-		}
-		return $force;
-	}
-
-	/**
-	 * Check if current cart contains subscription items added by this plugin.
-	 *
-	 * @return bool
-	 */
-	private function cart_has_subscription_items(): bool {
-		if ( function_exists( 'WC' ) && WC()->cart ) {
-			$cart_items = WC()->cart->get_cart_contents() ?? [];
-			$recurs     = Helper::get_recurrs_from_cart( $cart_items );
-
-			if ( ! empty( $recurs ) ) {
+		/**
+		 * Mirror of the above for gateways using wc_stripe_force_save_payment_method filter.
+		 *
+		 * @param bool $force    Whether to force save the payment method.
+		 * @param int  $order_id Order ID if available during confirmation.
+		 * @return bool
+		 */
+		public function force_save_payment_method_for_subscriptions( $force, $order_id = 0 ) {
+			if ( $this->cart_has_subscription_items() ) {
 				return true;
 			}
+			if ( $order_id && $this->order_has_subscription_relation( (int) $order_id ) ) {
+				return true;
+			}
+			return $force;
 		}
-		return false;
-	}
 
-	/**
-	 * Determine if a given order has subscription relation rows in our mapping table.
-	 *
-	 * @param int $order_id The WooCommerce order ID to check.
-	 * @return bool
-	 */
-	private function order_has_subscription_relation( int $order_id ): bool {
-		$histories = Helper::get_subscriptions_from_order( $order_id );
-		return ! empty( $histories );
-	}
+		/**
+		 * Check if current cart contains subscription items added by this plugin.
+		 *
+		 * @return bool
+		 */
+		private function cart_has_subscription_items(): bool {
+			if ( function_exists( 'WC' ) && WC()->cart ) {
+				$cart_items = WC()->cart->get_cart_contents() ?? [];
+				$recurs     = Helper::get_recurrs_from_cart( $cart_items );
 
-	/**
-	 * Detect if given order id is a renewal order created by this plugin.
-	 *
-	 * @param int $order_id Order ID.
-	 * @return bool
-	 */
-	private function is_subscription_renewal_order( $order_id ) {
-		global $wpdb;
-		$table_name = $wpdb->prefix . 'subscrpt_order_relation';
-		// @phpcs:ignore
-		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT type FROM %i WHERE order_id=%d ORDER BY id DESC', array( $table_name, $order_id ) ) );
-		return ( $row && isset( $row->type ) && 'renew' === $row->type );
-	}
+				if ( ! empty( $recurs ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
 
-	/**
-	 * Modify create intent request to add setup_future_usage and customer when needed.
-	 *
-	 * @param array     $request         The arguments for the request.
-	 * @param \WC_Order $order           The order that is being paid for.
-	 * @param object    $prepared_source The source that is used for the payment.
-	 */
-	public function modify_create_intent_request_for_subscriptions( $request, $order, $prepared_source ) {
-		$is_subscription_order = $this->order_has_subscription_relation( $order->get_id() );
-		if ( ! $is_subscription_order ) {
+		/**
+		 * Determine if a given order has subscription relation rows in our mapping table.
+		 *
+		 * @param int $order_id The WooCommerce order ID to check.
+		 * @return bool
+		 */
+		private function order_has_subscription_relation( int $order_id ): bool {
+			$histories = Helper::get_subscriptions_from_order( $order_id );
+			return ! empty( $histories );
+		}
+
+		/**
+		 * Detect if given order id is a renewal order created by this plugin.
+		 *
+		 * @param int $order_id Order ID.
+		 * @return bool
+		 */
+		private function is_subscription_renewal_order( $order_id ) {
+			global $wpdb;
+			$table_name = $wpdb->prefix . 'subscrpt_order_relation';
+			// @phpcs:ignore
+			$row = $wpdb->get_row( $wpdb->prepare( 'SELECT type FROM %i WHERE order_id=%d ORDER BY id DESC', array( $table_name, $order_id ) ) );
+			return ( $row && isset( $row->type ) && 'renew' === $row->type );
+		}
+
+		/**
+		 * Modify create intent request to add setup_future_usage and customer when needed.
+		 *
+		 * @param array     $request         The arguments for the request.
+		 * @param \WC_Order $order           The order that is being paid for.
+		 * @param object    $prepared_source The source that is used for the payment.
+		 */
+		public function modify_create_intent_request_for_subscriptions( $request, $order, $prepared_source ) {
+			$is_subscription_order = $this->order_has_subscription_relation( $order->get_id() );
+			if ( ! $is_subscription_order ) {
+				return $request;
+			}
+
+			$request['setup_future_usage']              = 'off_session';
+			$request['metadata']['save_payment_method'] = 'true';
+
+			// Ensure we have a customer for future payments
+			if ( ! empty( $prepared_source->customer ) ) {
+				$request['customer'] = $prepared_source->customer;
+			}
+
+			if ( isset( $request['confirm'] ) && true === $request['confirm'] ) {
+				if ( in_array( $order->get_payment_method(), self::WPSUBS_MANDATE_NEEDED_METHODS, true ) ) {
+					$request['mandate_data'] = [
+						'customer_acceptance' => [
+							'type' => 'offline',
+						],
+					];
+				}
+			}
+
 			return $request;
 		}
-
-		$request['setup_future_usage']              = 'off_session';
-		$request['metadata']['save_payment_method'] = 'true';
-
-		// Ensure we have a customer for future payments
-		if ( ! empty( $prepared_source->customer ) ) {
-			$request['customer'] = $prepared_source->customer;
-		}
-
-		if ( isset( $request['confirm'] ) && true === $request['confirm'] ) {
-			if ( in_array( $order->get_payment_method(), self::WPSUBS_MANDATE_NEEDED_METHODS, true ) ) {
-				$request['mandate_data'] = [
-					'customer_acceptance' => [
-						'type' => 'offline',
-					],
-				];
-			}
-		}
-
-		return $request;
 	}
-}
+} // end class_exists guard

--- a/includes/Installer.php
+++ b/includes/Installer.php
@@ -30,7 +30,7 @@ class Installer {
 			update_option( 'subscrpt_installed', time() );
 		}
 
-		update_option( 'subscrpt_version', WP_SUBSCRIPTION_VERSION );
+		update_option( 'subscrpt_version', SUBSCRPT_VERSION );
 
 		update_option( 'subscrpt_manual_renew_cart_notice', 'Subscriptional product added to cart. Please complete the checkout to renew subscription.' );
 	}

--- a/includes/LegacyCompat.php
+++ b/includes/LegacyCompat.php
@@ -58,6 +58,8 @@ if ( ! function_exists( 'wp_subscrpt_write_debug_log' ) ) {
 	 * @deprecated Use subscrpt_write_debug_log() instead.
 	 */
 	function wp_subscrpt_write_debug_log( $log ): void {
+		_deprecated_function( 'wp_subscrpt_write_debug_log', '1.9.3', 'subscrpt_write_debug_log' );
+
 		subscrpt_write_debug_log( $log );
 	}
 }
@@ -67,6 +69,8 @@ if ( ! function_exists( 'wp_subs_multiselect_field' ) ) {
 	 * @deprecated Use subscrpt_multiselect_field() instead.
 	 */
 	function wp_subs_multiselect_field( $field ) {
+		_deprecated_function( 'wp_subs_multiselect_field', '1.9.3', 'subscrpt_multiselect_field' );
+
 		subscrpt_multiselect_field( $field );
 	}
 }
@@ -76,6 +80,8 @@ if ( ! function_exists( 'wp_subscription_register_paypal_block' ) ) {
 	 * @deprecated Use subscrpt_register_paypal_block() instead.
 	 */
 	function wp_subscription_register_paypal_block() {
+		_deprecated_function( 'wp_subscription_register_paypal_block', '1.9.3', 'subscrpt_register_paypal_block' );
+
 		subscrpt_register_paypal_block();
 	}
 }

--- a/includes/LegacyCompat.php
+++ b/includes/LegacyCompat.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Legacy Compatibility Layer
+ *
+ * Re-declares old WP_SUBSCRIPTION_* constants and wp_-prefixed function names
+ * as thin wrappers around the canonical SUBSCRPT_* equivalents.
+ *
+ * This file is loaded immediately after the canonical constants and functions
+ * are defined, so Pro plugin and any third-party code that depends on the old
+ * names continues to work without modification.
+ *
+ * @package Subscription
+ */
+
+// don't call the file directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy constants  (WP_SUBSCRIPTION_* → SUBSCRPT_*)
+// ---------------------------------------------------------------------------
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+$subscrpt_legacy_constants = array(
+	'WP_SUBSCRIPTION_VERSION'   => SUBSCRPT_VERSION,
+	'WP_SUBSCRIPTION_FILE'      => SUBSCRPT_FILE,
+	'WP_SUBSCRIPTION_PATH'      => SUBSCRPT_PATH,
+	'WP_SUBSCRIPTION_INCLUDES'  => SUBSCRPT_INCLUDES,
+	'WP_SUBSCRIPTION_TEMPLATES' => SUBSCRPT_TEMPLATES,
+	'WP_SUBSCRIPTION_URL'       => SUBSCRPT_URL,
+	'WP_SUBSCRIPTION_ASSETS'    => SUBSCRPT_ASSETS,
+);
+
+foreach ( $subscrpt_legacy_constants as $subscrpt_old_name => $subscrpt_new_value ) {
+	if ( ! defined( $subscrpt_old_name ) ) {
+		define( $subscrpt_old_name, $subscrpt_new_value );
+	}
+}
+unset( $subscrpt_legacy_constants, $subscrpt_old_name, $subscrpt_new_value );
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+
+// ---------------------------------------------------------------------------
+// Legacy functions  (wp_-prefixed → subscrpt_-prefixed)
+// ---------------------------------------------------------------------------
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+
+if ( ! function_exists( 'wp_subscrpt_write_log' ) ) {
+	/**
+	 * @deprecated Use subscrpt_write_log() instead.
+	 */
+	function wp_subscrpt_write_log( $message, bool $should_print = false ): void {
+		subscrpt_write_log( $message, $should_print );
+	}
+}
+
+if ( ! function_exists( 'wp_subscrpt_write_debug_log' ) ) {
+	/**
+	 * @deprecated Use subscrpt_write_debug_log() instead.
+	 */
+	function wp_subscrpt_write_debug_log( $log ): void {
+		subscrpt_write_debug_log( $log );
+	}
+}
+
+if ( ! function_exists( 'wp_subs_multiselect_field' ) ) {
+	/**
+	 * @deprecated Use subscrpt_multiselect_field() instead.
+	 */
+	function wp_subs_multiselect_field( $field ) {
+		subscrpt_multiselect_field( $field );
+	}
+}
+
+if ( ! function_exists( 'wp_subscription_register_paypal_block' ) ) {
+	/**
+	 * @deprecated Use subscrpt_register_paypal_block() instead.
+	 */
+	function wp_subscription_register_paypal_block() {
+		subscrpt_register_paypal_block();
+	}
+}
+
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound

--- a/includes/LegacyCompat.php
+++ b/includes/LegacyCompat.php
@@ -58,7 +58,7 @@ if ( ! function_exists( 'wp_subscrpt_write_debug_log' ) ) {
 	 * @deprecated Use subscrpt_write_debug_log() instead.
 	 */
 	function wp_subscrpt_write_debug_log( $log ): void {
-		_deprecated_function( 'wp_subscrpt_write_debug_log', '1.9.3', 'subscrpt_write_debug_log' );
+		_deprecated_function( 'wp_subscrpt_write_debug_log', '1.9.2', 'subscrpt_write_debug_log' );
 
 		subscrpt_write_debug_log( $log );
 	}
@@ -69,7 +69,7 @@ if ( ! function_exists( 'wp_subs_multiselect_field' ) ) {
 	 * @deprecated Use subscrpt_multiselect_field() instead.
 	 */
 	function wp_subs_multiselect_field( $field ) {
-		_deprecated_function( 'wp_subs_multiselect_field', '1.9.3', 'subscrpt_multiselect_field' );
+		_deprecated_function( 'wp_subs_multiselect_field', '1.9.2', 'subscrpt_multiselect_field' );
 
 		subscrpt_multiselect_field( $field );
 	}
@@ -80,7 +80,7 @@ if ( ! function_exists( 'wp_subscription_register_paypal_block' ) ) {
 	 * @deprecated Use subscrpt_register_paypal_block() instead.
 	 */
 	function wp_subscription_register_paypal_block() {
-		_deprecated_function( 'wp_subscription_register_paypal_block', '1.9.3', 'subscrpt_register_paypal_block' );
+		_deprecated_function( 'wp_subscription_register_paypal_block', '1.9.2', 'subscrpt_register_paypal_block' );
 
 		subscrpt_register_paypal_block();
 	}

--- a/includes/Traits/Email.php
+++ b/includes/Traits/Email.php
@@ -151,7 +151,7 @@ trait Email {
 	 * @return void
 	 */
 	public function set_template( string $id ) {
-		$this->template_base = WP_SUBSCRIPTION_TEMPLATES;
+		$this->template_base = SUBSCRPT_TEMPLATES;
 		if ( isset( $this->templates[ $id ] ) ) {
 			$this->template_html  = $this->templates[ $id ]['html'];
 			$this->template_plain = $this->templates[ $id ]['plain'];

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -14,7 +14,7 @@ use SpringDevs\Subscription\Utils\Product;
  * * Use "`yarn watch:tailwind`" to continuously build the tailwind CSS file.
  */
 function subscrpt_include_tailwind_css() {
-	wp_enqueue_style( 'wpsubs-tailwind', WP_SUBSCRIPTION_ASSETS . '/css/tailwind/output.css', [], WP_SUBSCRIPTION_VERSION );
+	wp_enqueue_style( 'wpsubs-tailwind', SUBSCRPT_ASSETS . '/css/tailwind/output.css', [], SUBSCRPT_VERSION );
 }
 
 /**
@@ -552,7 +552,7 @@ function sdevs_get_subscription_product( $product ) {
  * @param mixed $message      Message.
  * @param bool  $should_print Print the output.
  */
-function wp_subscrpt_write_log( $message, bool $should_print = false ): void {
+function subscrpt_write_log( $message, bool $should_print = false ): void {
 	$logger = wc_get_logger();
 
 	$message = is_array( $message ) || is_object( $message ) ? wp_json_encode( $message ) : $message;
@@ -566,7 +566,7 @@ function wp_subscrpt_write_log( $message, bool $should_print = false ): void {
  *
  * @param mixed $log logs.
  */
-function wp_subscrpt_write_debug_log( $log ): void {
+function subscrpt_write_debug_log( $log ): void {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
 		if ( is_array( $log ) || is_object( $log ) ) {
 			error_log( print_r( $log, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
@@ -653,7 +653,7 @@ function subscrpt_add_payment_completion_note( $subscription_id, $payments_made,
  *     @type string       $name              Optional. Input name. Defaults to $id.'[]'.
  * }
  */
-function wp_subs_multiselect_field( $field ) {
+function subscrpt_multiselect_field( $field ) {
 	$defaults = [
 		'id'            => '',
 		'label'         => '',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscription",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "author": "The WordPress Contributors",
   "license": "GPL-2.0-or-later",
   "main": "build/index.js",

--- a/readme-template.txt
+++ b/readme-template.txt
@@ -148,7 +148,7 @@ Subscriptions for WooCommerce is more than just a plugin, it's your key to unloc
 
 - Compatibility with top tools like LearnPress, WPML, and Membership plugins
 
-It's the perfect solution for anyone searching for a subscription plugin for WooCommerce that's built for performance, reliability, and growth.
+It's a solid choice for anyone searching for a subscription plugin for WooCommerce that's built for performance, reliability, and growth.
 
 ### SUBSCRIPTIONS FOR WOOCOMMERCE PLUGIN COMPATIBILITIES
 
@@ -172,7 +172,7 @@ This Plugin is also perfect for digital products. Selling online courses, downlo
 
 The **Subscription for WooCommerce plugin** works well with most themes that follow WordPress and WooCommerce standards. If any issue comes up after a theme or version update, the plugin team quickly makes it compatible again.
 
-Whether you're selling digital downloads, or services, it will help you grow with recurring revenue. It's the easiest way to make your WooCommerce store subscription-ready. If you are searching for the best WooCommerce recurring payment plugins, this solution is a powerful and user-friendly choice.
+Whether you're selling digital downloads, or services, it will help you grow with recurring revenue. It makes your WooCommerce store subscription-ready with minimal setup. If you are looking for a WooCommerce recurring payment solution, this is a powerful and user-friendly option.
 
 ### Need Help?
 
@@ -221,10 +221,10 @@ If a payment fails, the system will automatically retry the payment and send ale
 =Where can I find the full documentation and setup steps?=
 You can find the complete guide, configuration tutorials, and troubleshooting help in our [Subscriptions for WooCommerce Docs](https://docs.converslabs.com/en) section.
 
-=Is this one of the best WooCommerce recurring payment plugins?=
-Yes! We have designed it to be fast, reliable, and full-featured, with support for auto-renewals, variable products, free trials, and more! Everything you expect from a top-tier **Subscription for WooCommerce plugin**.
+=What makes this a good choice for WooCommerce subscriptions?=
+It is designed to be fast, reliable, and full-featured, with support for auto-renewals, variable products, free trials, and multiple payment gateways including Stripe and PayPal.
 
-With Subscriptions for WooCommerce, you can turn your store into a subscription business in just minutes. Try this plugin today and discover why many store owners consider it among the best WooCommerce recurring payment plugins available.
+With Subscriptions for WooCommerce, you can turn your store into a subscription business in just minutes using a lightweight plugin with no bloat.
 
 == Installation ==
 

--- a/readme-template.txt
+++ b/readme-template.txt
@@ -1,4 +1,4 @@
-=== Subscription & Recurring Payment Plugin for WooCommerce ===
+=== Subscription & Recurring Payment for WooCommerce ===
 Contributors: converswp, shamsbd71, aushamim
 Tags: woocommerce subscriptions, subscriptions, recurring, billing, stripe
 Requires at least: 6.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: converswp, shamsbd71, aushamim
 Tags: woocommerce subscriptions, subscriptions, recurring, billing, stripe
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 Requires PHP: 7.4
 WC requires at least: 6.0
 WC tested up to: 10.3
@@ -278,6 +278,18 @@ Learn more: [WPSubscription](https://wpsubscription.co/)
 19. Create WooCommerce Product with Subscription Option
 
 == Changelog ==
+
+= 1.9.2 - Mar 29, 2026 =
+-  fix: Renamed reserved WP_SUBSCRIPTION_* constants to SUBSCRPT_* to comply with WordPress.org naming guidelines.
+-  fix: Renamed wp_-prefixed global functions (wp_subscrpt_write_log, wp_subs_multiselect_field, etc.) to subscrpt_ prefix.
+-  fix: Renamed non-prefixed AJAX actions (install_woocommerce_plugin, activate_woocommerce_plugin) to subscrpt_ prefix.
+-  fix: Stripe gateway class now wrapped in class_exists check to prevent fatal error when WooCommerce Stripe plugin is inactive.
+-  fix: Guest checkout auto-login now restricted to newly created accounts only, preventing unexpected re-login for existing users.
+-  fix: Replaced insecure JavaScript location.href redirects in ActionController with wp_safe_redirect().
+-  fix: PayPal webhook inputs now sanitized before processing.
+-  fix: Settings field output now escaped with wp_kses_post for improved security.
+-  fix: Plugin name updated to comply with WordPress.org trademark guidelines.
+-  compat: Legacy WP_SUBSCRIPTION_* constants and old function names remain available via includes/LegacyCompat.php.
 
 = 1.9.1 - Mar 15, 2026 =
 -   fix: Subscription trials.

--- a/readme.txt
+++ b/readme.txt
@@ -148,7 +148,7 @@ Subscriptions for WooCommerce is more than just a plugin, it's your key to unloc
 
 - Compatibility with top tools like LearnPress, WPML, and Membership plugins
 
-It's the perfect solution for anyone searching for a subscription plugin for WooCommerce that's built for performance, reliability, and growth.
+It's a solid choice for anyone searching for a subscription plugin for WooCommerce that's built for performance, reliability, and growth.
 
 ### SUBSCRIPTIONS FOR WOOCOMMERCE PLUGIN COMPATIBILITIES
 
@@ -172,7 +172,7 @@ This Plugin is also perfect for digital products. Selling online courses, downlo
 
 The **Subscription for WooCommerce plugin** works well with most themes that follow WordPress and WooCommerce standards. If any issue comes up after a theme or version update, the plugin team quickly makes it compatible again.
 
-Whether you're selling digital downloads, or services, it will help you grow with recurring revenue. It's the easiest way to make your WooCommerce store subscription-ready. If you are searching for the best WooCommerce recurring payment plugins, this solution is a powerful and user-friendly choice.
+Whether you're selling digital downloads, or services, it will help you grow with recurring revenue. It makes your WooCommerce store subscription-ready with minimal setup. If you are looking for a WooCommerce recurring payment solution, this is a powerful and user-friendly option.
 
 ### Need Help?
 
@@ -221,10 +221,10 @@ If a payment fails, the system will automatically retry the payment and send ale
 =Where can I find the full documentation and setup steps?=
 You can find the complete guide, configuration tutorials, and troubleshooting help in our [Subscriptions for WooCommerce Docs](https://docs.converslabs.com/en) section.
 
-=Is this one of the best WooCommerce recurring payment plugins?=
-Yes! We have designed it to be fast, reliable, and full-featured, with support for auto-renewals, variable products, free trials, and more! Everything you expect from a top-tier **Subscription for WooCommerce plugin**.
+=What makes this a good choice for WooCommerce subscriptions?=
+It is designed to be fast, reliable, and full-featured, with support for auto-renewals, variable products, free trials, and multiple payment gateways including Stripe and PayPal.
 
-With Subscriptions for WooCommerce, you can turn your store into a subscription business in just minutes. Try this plugin today and discover why many store owners consider it among the best WooCommerce recurring payment plugins available.
+With Subscriptions for WooCommerce, you can turn your store into a subscription business in just minutes using a lightweight plugin with no bloat.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Subscription & Recurring Payment Plugin for WooCommerce ===
+=== Subscription & Recurring Payment for WooCommerce ===
 Contributors: converswp, shamsbd71, aushamim
 Tags: woocommerce subscriptions, subscriptions, recurring, billing, stripe
 Requires at least: 6.0

--- a/subscription.php
+++ b/subscription.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Subscription & Recurring Payment Plugin for WooCommerce
+ * Plugin Name: Subscription & Recurring Payment for WooCommerce
  * Plugin URI: https://wpsubscription.co/
  * Description: WPSubscription allow WooCommerce to enables recurring payments, subscriptions, and auto-renewals for digital and physical products. Supports Stripe, PayPal, Paddle, and more.
  *
@@ -21,6 +21,9 @@
  * WC tested up to: 10.3
  *
  * Requires Plugins: woocommerce
+ *
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *
  * @package Subscription
  */

--- a/subscription.php
+++ b/subscription.php
@@ -125,13 +125,17 @@ final class Sdevs_Subscription {
 	 * @return void
 	 */
 	public function define_constants() {
-		define( 'WP_SUBSCRIPTION_VERSION', self::VERSION );
-		define( 'WP_SUBSCRIPTION_FILE', __FILE__ );
-		define( 'WP_SUBSCRIPTION_PATH', dirname( WP_SUBSCRIPTION_FILE ) );
-		define( 'WP_SUBSCRIPTION_INCLUDES', WP_SUBSCRIPTION_PATH . '/includes' );
-		define( 'WP_SUBSCRIPTION_TEMPLATES', WP_SUBSCRIPTION_PATH . '/templates/' );
-		define( 'WP_SUBSCRIPTION_URL', plugins_url( '', WP_SUBSCRIPTION_FILE ) );
-		define( 'WP_SUBSCRIPTION_ASSETS', WP_SUBSCRIPTION_URL . '/assets' );
+		define( 'SUBSCRPT_VERSION', self::VERSION );
+		define( 'SUBSCRPT_FILE', __FILE__ );
+		define( 'SUBSCRPT_PATH', dirname( SUBSCRPT_FILE ) );
+		define( 'SUBSCRPT_INCLUDES', SUBSCRPT_PATH . '/includes' );
+		define( 'SUBSCRPT_TEMPLATES', SUBSCRPT_PATH . '/templates/' );
+		define( 'SUBSCRPT_URL', plugins_url( '', SUBSCRPT_FILE ) );
+		define( 'SUBSCRPT_ASSETS', SUBSCRPT_URL . '/assets' );
+
+		// Load legacy constant aliases (WP_SUBSCRIPTION_* → SUBSCRPT_*) for
+		// backwards compatibility with subscription-pro and third-party code.
+		require_once SUBSCRPT_INCLUDES . '/LegacyCompat.php';
 	}
 
 	/**
@@ -168,7 +172,7 @@ final class Sdevs_Subscription {
 	 */
 	public function includes() {
 		// Include functions file first to ensure global functions are available
-		require_once WP_SUBSCRIPTION_INCLUDES . '/functions.php';
+		require_once SUBSCRPT_INCLUDES . '/functions.php';
 
 		if ( $this->is_request( 'admin' ) ) {
 			$this->container['admin'] = new SpringDevs\Subscription\Admin();
@@ -287,11 +291,11 @@ final class Sdevs_Subscription {
 } // Sdevs_Wc_Subscription
 
 // Add Paypal Gateway Blocks.
-if ( ! function_exists( 'wp_subscription_register_paypal_block' ) ) {
+if ( ! function_exists( 'subscrpt_register_paypal_block' ) ) {
 	/**
 	 * Register the PayPal block for WooCommerce Blocks.
 	 */
-	function wp_subscription_register_paypal_block() {
+	function subscrpt_register_paypal_block() {
 		// Check if the required class exists.
 		if ( ! class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
 			return;
@@ -311,7 +315,7 @@ if ( ! function_exists( 'wp_subscription_register_paypal_block' ) ) {
 		// Is PayPal integration enabled?
 		$is_paypal_integration_enabled = 'on' === get_option( 'wp_subs_paypal_integration_enabled', 'off' );
 		if ( $is_paypal_integration_enabled ) {
-			add_action( 'woocommerce_blocks_loaded', 'wp_subscription_register_paypal_block' );
+			add_action( 'woocommerce_blocks_loaded', 'subscrpt_register_paypal_block' );
 		}
 	}
 }

--- a/templates/myaccount/single.php
+++ b/templates/myaccount/single.php
@@ -1,4 +1,8 @@
 <?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 /**
  * Single subscription page
  *


### PR DESCRIPTION
2026-03-29 - version 1.9.2
* fix: Renamed reserved WP_SUBSCRIPTION_* constants to SUBSCRPT_* to comply with WordPress.org naming guidelines.
* fix: Renamed wp_-prefixed global functions (wp_subscrpt_write_log, wp_subs_multiselect_field, etc.) to subscrpt_ prefix.
* fix: Renamed non-prefixed AJAX actions (install_woocommerce_plugin, activate_woocommerce_plugin) to subscrpt_ prefix.
* fix: Stripe gateway class now wrapped in class_exists check to prevent fatal error when WooCommerce Stripe plugin is inactive.
* fix: Guest checkout auto-login now restricted to newly created accounts only, preventing unexpected re-login for existing users.
* fix: Replaced insecure JavaScript location.href redirects in ActionController with wp_safe_redirect().
* fix: PayPal webhook inputs now sanitized before processing.
* fix: Settings field output now escaped with wp_kses_post for improved security.
* fix: Plugin name updated to comply with WordPress.org trademark guidelines.
* compat: Legacy WP_SUBSCRIPTION_* constants and old function names remain available via includes/LegacyCompat.php.
