### PR TITLE
fix: PayPal pending orders and on-hold status

### DIFF
--- a/includes/Illuminate/Action.php
+++ b/includes/Illuminate/Action.php
@@ -62,6 +62,9 @@ class Action {
 			case 'pe_cancelled':
 				self::pe_cancelled( $subscription_id );
 				break;
+			case 'on-hold':
+				self::on_hold( $subscription_id );
+				break;
 		}
 	}
 
@@ -148,6 +151,26 @@ class Action {
 
 		// Fire split payment cancelled action
 		do_action( 'subscrpt_split_payment_cancelled', $subscription_id );
+	}
+
+	/**
+	 * Write Comment About On-Hold Subscription.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 */
+	private static function on_hold( int $subscription_id ) {
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_author'  => 'Subscription for WooCommerce',
+				'comment_content' => 'Subscription is On Hold. Access suspended after payment failure.',
+				'comment_post_ID' => $subscription_id,
+				'comment_type'    => 'order_note',
+			)
+		);
+		update_comment_meta( $comment_id, '_subscrpt_activity', 'Subscription On Hold' );
+		update_comment_meta( $comment_id, '_subscrpt_activity_type', 'subs_on_hold' );
+
+		do_action( 'subscrpt_subscription_on_hold', $subscription_id );
 	}
 
 	/**

--- a/includes/Illuminate/Gateways/Paypal/Paypal.php
+++ b/includes/Illuminate/Gateways/Paypal/Paypal.php
@@ -581,9 +581,11 @@ class Paypal extends \WC_Payment_Gateway {
 			}
 		}
 
-		// Gate subscription events only when both $order and $wpsubs_id are unresolved.
-		// Transaction events resolve $order internally; subscription events can use $wpsubs_id directly.
-		if ( empty( $order ) && empty( $wpsubs_id ) && in_array( $event, $subscription_events, true ) ) {
+		// Gate ALL events when both $order and $wpsubs_id are unresolved — return 425 so PayPal
+		// retries. Previously this guard was subscription-events-only; transaction events (e.g.
+		// PAYMENT.SALE.COMPLETED) fell through and returned a 404 which PayPal treats as a
+		// permanent failure and never retries, leaving the renewal order in "pending" forever.
+		if ( empty( $order ) && empty( $wpsubs_id ) ) {
 			$log_message = sprintf(
 				// translators: %s: event name.
 				__( 'PayPal webhook received [%s]. Order not found. Queuing for retry.', 'subscription' ),


### PR DESCRIPTION
## Summary

- **PayPal pending orders**: Extends the 425 retry gate from subscription events to ALL webhook events. Previously `PAYMENT.SALE.COMPLETED` returned 404 on failed resolution — PayPal treats 404 as permanent, no retry, renewal order stays pending forever.
- **`on-hold` hook**: Adds `case 'on-hold':` to `Action::write_comment()` and fires `subscrpt_subscription_on_hold` so suspension is logged and hookable.

## Companion PR

`converslabs/subscription-pro` fix/review-reddit — fixes `on_hold` typo and broken retry logic.

## Test plan

- [ ] PayPal renewal: simulate webhook with unknown mapping → confirm 425 in PayPal logs, retried
- [ ] Call `Action::status('on-hold', \$id)` → confirm note in subscription timeline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)